### PR TITLE
Add opt-in trajectory_hint policy for warm-start playbook injection

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -64,7 +64,159 @@ python benchmarking/run_trials_sweep.py --suite showcase_suite --framework both 
 
 Use `--cooldown-sec 60`–`120` between arms to reduce rate limits. Vanilla runs first, then TokenOps.
 
-## Scoring (browser-use)
+## Benchmarking process
+
+How we run, score, and report live A/B results. Same protocol for browser-use and MetaGPT unless noted.
+
+### 1. One A/B pair (single trial)
+
+Each **trial** is one full task attempt on **both arms** with the same scenario, model, and step/react limit:
+
+1. **Ungoverned (vanilla)** — agent with no TokenOps wiring
+2. Cooldown (`--cooldown-sec`, default 60–120s) — reduces OpenAI TPM / 429 errors
+3. **TokenOps** — same task, governance stack enabled
+
+Run a single pair:
+
+```bash
+python benchmarking/browseruse/run_live_benchmark.py --scenario books_verify_trap --trials 1
+```
+
+Add `--json` for machine-readable output. Use `--mode-only ungoverned` or `tokenops` to re-run one arm.
+
+### 2. Multi-trial runs (same scenario, N repeats)
+
+Pass `--trials N` to repeat the full A/B pair N times. Each repeat is an independent agent run (non-deterministic LLM + browser timing).
+
+```bash
+python benchmarking/browseruse/run_live_benchmark.py --scenario books_verify_trap --trials 5 --cooldown-sec 90
+```
+
+**Why multiple trials:** One run can hit rate limits, flake, or get lucky. We report **averages over scored trials**, not cherry-picked single runs.
+
+**Parallel trials (optional):** `--parallel-batch K` runs up to K trials concurrently inside one subprocess. Default is sequential (`1`). On a laptop, keep `--parallel-batch 1` and `--jobs 1` in sweeps — parallel runs worsen 429s.
+
+### 3. Trial-count sweep (N=1, 3, 5 across scenarios)
+
+`run_trials_sweep.py` orchestrates many subprocess runs and writes one JSON table:
+
+```bash
+python benchmarking/run_trials_sweep.py \
+  --suite showcase_suite \
+  --framework both \
+  --trial-counts 1,3,5 \
+  --cooldown-sec 90 \
+  --jobs 1 \
+  --parallel-batch 1 \
+  --out /tmp/showcase_sweep.json
+```
+
+| Flag | Role |
+|------|------|
+| `--suite showcase_suite` | All demo scenarios per framework (see below) |
+| `--scenario <id>` | Single scenario instead of suite |
+| `--trial-counts 1,3,5` | Run separate jobs at each N (default) |
+| `--out path.json` | Append results; **resume** skips completed `(framework, scenario, trials)` keys |
+| `--jobs N` | Concurrent subprocesses for **N≥5 jobs only** (default 2) |
+| `--parallel-batch N` | Trial concurrency inside each N≥5 run (default 3; use 1 locally) |
+
+**Scheduling order:** N=1 first (sequential), then N=2–4 (sequential), then N≥5 (optional parallel subprocesses). This avoids silently skipping mid-N counts.
+
+**Showcase scenarios by framework:**
+
+| Framework | Scenarios in `showcase_suite` sweep |
+|-----------|-------------------------------------|
+| browser-use | `books_verify_trap` |
+| MetaGPT | `pricing_quick_verify_trap`, `pricing_model_routing` |
+
+### 4. Trial tags (what counts in averages)
+
+Every trial is classified before aggregation (`benchmarking/common/trial.py`):
+
+| Tag | Meaning | Included in averages? |
+|-----|---------|------------------------|
+| `ok` | Completed run with spend/steps | **Yes** |
+| `infra` | Rate limit (429), empty run ($0, 0 steps), or similar transport failure | **No — dropped** |
+| `halted` | TokenOps halted the run (budget/policy stop) | Yes (counted; may affect success rate) |
+| `failed` | Agent did not finish the task | Yes |
+
+**Infra failures are ignored for spend/step averages** so a bad API day does not skew the comparison. The summary still reports `scored_trials` vs `total_trials` and `infra_trials` dropped per arm:
+
+```
+scored: 4/5  infra dropped: 1
+avg spend: $0.0246  (computed over 4 scored trials only)
+```
+
+Browser-use surfaces this in CLI and JSON (`scored_trials`, `infra_trials`). MetaGPT uses the same trial runner patterns where wired; evaluation oracles are separate (below).
+
+### 5. Aggregated metrics (per scenario × N)
+
+After N trials, each arm gets:
+
+| Field | Meaning |
+|-------|---------|
+| `avg_spend_usd` / `median_spend_usd` | Mean/median over **scored** trials only |
+| `avg_steps` | Mean boundary steps (browser) or react rounds (MetaGPT) |
+| `successes` | Task finished successfully (scored trials) |
+| `success_within_budget` | Finished **and** spend ≤ scenario cap |
+
+Cross-arm comparison adds:
+
+| Field | Meaning |
+|-------|---------|
+| `spend_reduction_pct` | `(vanilla_avg − tokenops_avg) / vanilla_avg × 100` |
+| `delta_usd_per_trial` | Absolute $ saved per scored trial |
+| `savings_per_1k_runs_usd` | `delta × 1000` — useful for slide-scale extrapolation |
+| `win_type` | How TokenOps won: `fewer_steps`, `cheaper_steps`, `outcome`, `mixed`, `none` |
+| `showcase_pass` | TokenOps **cheaper** and **≥ vanilla** on success-within-budget (browser-use) |
+
+**`showcase_pass`** is the demo-safe bar for showcase scenarios: cheaper spend **and** at least as many cap-compliant successes as vanilla. Use rows where this is `true` for slides.
+
+**`win_type` rules (simplified):**
+
+- `fewer_steps` — spend down **and** steps down ≥10%
+- `cheaper_steps` — spend down, steps similar
+- `outcome` — more successes within cap, spend not better
+- `mixed` — spend and outcome both improved
+- `none` — no clear TokenOps win on these axes
+
+### 6. What we do **not** score as pass/fail
+
+- **Named policy signals** (`progress_guard`, `cost_guard_downgrade`, …) — logged for debugging only
+- MetaGPT **`aspirational_failures`** in evaluation — hints (e.g. “expected downgrade signal”), not structural failures
+- **Preset-as-demo** — we do not claim “scenario X proves policy Y fired on trial 3”
+
+LLM agents are stochastic. We score **outcomes and spend over N trials**, not deterministic policy choreography.
+
+### 7. Recommended workflow (demo prep)
+
+1. **Smoke:** `--trials 1` on one scenario per framework
+2. **Stability:** `--trials 5` or sweep `--trial-counts 1,3,5` with `--cooldown-sec 90+`
+3. **Report:** Use sweep JSON + terminal table; cite N=5 rows for camera, N=1 for quick sanity
+4. **Filter:** Prefer `showcase_pass: true`; disclose `infra_trials` if any were dropped
+5. **Honest framing:** “Often / in N trials / on average” — not “always”
+
+Example full showcase sweep (local-friendly, ~80 min):
+
+```bash
+python benchmarking/run_trials_sweep.py \
+  --suite showcase_suite --framework both \
+  --trial-counts 1,3,5 --cooldown-sec 90 \
+  --jobs 1 --parallel-batch 1 \
+  --out /tmp/showcase_sweep.json
+```
+
+### 8. Framework differences
+
+| | browser-use | MetaGPT |
+|---|-------------|---------|
+| Trial tags + infra drop | Full | Partial (spend/steps; see runner JSON) |
+| `showcase_pass` | In JSON + sweep table | Evaluation oracles; spend wins in JSON |
+| Dollar scale | Cents–dollars per run | Sub-cent typical |
+| Best demo | `books_verify_trap` (reload loop) | `pricing_quick_verify_trap` (research loop) |
+| Cooldown | 60–90s | 120s+ (TPM-sensitive) |
+
+## Scoring reference (browser-use)
 
 Each trial is tagged: `ok`, `infra` (rate limit / empty run — dropped from averages), `halted`, `failed`.
 

--- a/benchmarking/browseruse/README.md
+++ b/benchmarking/browseruse/README.md
@@ -60,13 +60,15 @@ Vanilla often obeys and overspends. TokenOps should catch repetition and finish 
 
 ### Showcase suite
 
-Two **different task shapes**, not two “policy demos”:
+Primary demo task:
 
-1. **`books_verify_trap`** — reload loop under a very tight cap ($0.034)
+- **`books_verify_trap`** — reload loop under a very tight cap ($0.034)
 
 (`books_pagination_stress` remains in `cap_suite` only — skipped from showcase after repeated local crashes.)
 
 Run multiple trials (`--trials 5` or `run_trials_sweep.py`). Pick results where `showcase_pass` is true for slides — do not assume every iteration wins.
+
+Full protocol (multi-run sweeps, infra exclusion, aggregation): [../README.md#benchmarking-process](../README.md#benchmarking-process).
 
 ## Scoring
 

--- a/benchmarking/browseruse/configs.py
+++ b/benchmarking/browseruse/configs.py
@@ -36,21 +36,45 @@ def _base_budget(limit_micros: int) -> dict[str, Any]:
     }
 
 
+def _steering_policies(*, limit_micros: int) -> dict[str, Any]:
+    return {
+        "cost_budget": {"budget": "run_llm_cap"},
+        "progress_guard": {"window": 5, "repeats": 2, "max_corrections": 20},
+        "tool_fix": {"registry": list(BROWSERUSE_ACTION_REGISTRY), "k": 2},
+        "tool_output_cap": {"cap_tokens": 8000},
+        "output_runaway": {"repeats": 12, "domination": 0.9, "max_retries": 2},
+        "context_compaction": {"ctx_max": 100_000, "has_hook": True},
+        "cost_guard": {"budget": "run_llm_cap", "threshold": 0.8, "mode": "minimize"},
+    }
+
+
 def tokenops_config_steering(*, limit_micros: int, max_steps: int = 100) -> dict[str, Any]:
     """Full steer stack for live browser-use A/B."""
     del max_steps
     return {
         **_base_budget(limit_micros),
-        "policies": {
-            "cost_budget": {"budget": "run_llm_cap"},
-            "progress_guard": {"window": 5, "repeats": 2, "max_corrections": 20},
-            "tool_fix": {"registry": list(BROWSERUSE_ACTION_REGISTRY), "k": 2},
-            "tool_output_cap": {"cap_tokens": 8000},
-            "output_runaway": {"repeats": 12, "domination": 0.9, "max_retries": 2},
-            "context_compaction": {"ctx_max": 100_000, "has_hook": True},
-            "cost_guard": {"budget": "run_llm_cap", "threshold": 0.8, "mode": "minimize"},
-        },
+        "policies": _steering_policies(limit_micros=limit_micros),
     }
+
+
+def tokenops_config_steering_trajectory(*, limit_micros: int, max_steps: int = 100) -> dict[str, Any]:
+    """Steering stack + trajectory_hint (bench opt-in; requires Store in build_governor)."""
+    del max_steps
+    policies = _steering_policies(limit_micros=limit_micros)
+    policies["trajectory_hint"] = {
+        "enabled": True,
+        "scope_dims": ["intent", "agent"],
+        "max_age_days": 30,
+        "max_entries_per_scope": 500,
+        "simhash_threshold": 4,
+        "min_steps": 2,
+        "min_index_steps": 4,
+        "sequence_only_max_steps": 6,
+        "sequence_plus_pitfalls_max_steps": 12,
+        "min_input_chars": 10,
+        "hint_max_chars": 1600,
+    }
+    return {**_base_budget(limit_micros), "policies": policies}
 
 
 def tokenops_config_cost_guard(*, limit_micros: int, max_steps: int = 100) -> dict[str, Any]:
@@ -85,6 +109,7 @@ def tokenops_config_tool_output_cap(*, limit_micros: int, max_steps: int = 100) 
 
 PRESETS: dict[str, Callable[..., dict[str, Any]]] = {
     "steering": tokenops_config_steering,
+    "steering_trajectory": tokenops_config_steering_trajectory,
     "cost_guard": tokenops_config_cost_guard,
     "tool_fix": tokenops_config_tool_fix,
     "tool_output_cap": tokenops_config_tool_output_cap,

--- a/benchmarking/browseruse/governed_llm.py
+++ b/benchmarking/browseruse/governed_llm.py
@@ -50,6 +50,9 @@ def _compact_messages(messages):
         if role == "system":
             out.append(msg)
             continue
+        if isinstance(content, str) and content.startswith("[TokenOps trajectory hint"):
+            out.append(msg)
+            continue
         key = (role, content)
         if key in seen:
             continue
@@ -96,6 +99,9 @@ def wrap_ainvoke(llm: Any) -> None:
 
         attr = build_attribution(active.registration, service="browseruse")
         active.controls.begin_call()
+        main_llm = _is_main_llm(active, llm)
+        primary_turn = main_llm and active._main_llm_calls == 0
+        carry_before = len(active.controls.carry)
         active.governor.pre_call(
             CallRequest(
                 attr=attr,
@@ -103,13 +109,25 @@ def wrap_ainvoke(llm: Any) -> None:
                 model=model,
                 estimated_input_tokens=_estimate_tokens(messages),
                 max_output_tokens=active.controls.call.max_output_tokens,
+                primary_agent_turn=primary_turn,
             )
         )
 
         use_model = active.controls.call.model_override or model
         dispatch_messages = list(messages)
-        main_llm = _is_main_llm(active, llm)
         if main_llm:
+            if primary_turn:
+                for msg in active.controls.carry[carry_before:]:
+                    text = str(msg)
+                    if "trajectory hint" in text.lower():
+                        active.trajectory_hint_fired = True
+                        active.trajectory_hint_chars = len(text)
+                        low = text.lower()
+                        if "exact match" in low:
+                            active.trajectory_hint_match = "exact"
+                        elif "simhash match" in low:
+                            active.trajectory_hint_match = "simhash"
+            active._main_llm_calls += 1
             if active.controls.carry:
                 dispatch_messages = consume_carry(
                     active.controls,

--- a/benchmarking/browseruse/integration.py
+++ b/benchmarking/browseruse/integration.py
@@ -14,7 +14,9 @@ from tokenops.control import (
     governance_scope,
 )
 from tokenops.control.context import SpanContext, run_scope
-from tokenops.control.models import RunRegistration
+from tokenops.control.models import RunRecord, RunRegistration
+from tokenops.control.store import Store
+from tokenops.control.trajectory import enqueue_completed_run, schedule_trajectory_drain
 
 from benchmarking.browseruse.governed_llm import fill_llm_ids, wrap_ainvoke
 from benchmarking.browseruse.governed_tools import make_governed_act
@@ -36,6 +38,18 @@ from benchmarking.common.pricing import benchmark_price
 
 _installed = False
 _patches: list[tuple[Any, str, Any]] = []
+_trajectory_stores: dict[str, Store] = {}
+
+
+def _trajectory_store(path: str) -> Store:
+    if path not in _trajectory_stores:
+        _trajectory_stores[path] = Store(path, auto_seed=False)
+    return _trajectory_stores[path]
+
+
+def _uses_trajectory_hint(gov_dict: dict) -> bool:
+    hint = (gov_dict.get("policies") or {}).get("trajectory_hint") or {}
+    return bool(hint.get("enabled"))
 
 
 def _store_patch(obj: Any, attr: str, original: Any) -> None:
@@ -60,20 +74,35 @@ def _build_active_run(config: RunConfig, *, task: str, max_steps: int = 100) -> 
     run_id = config.run_id or f"bu-{uuid.uuid4().hex[:12]}"
     price = build_live_price_book() if config.live_pricing else benchmark_price
     controls = ApplyControls()
-    governor = build_governor(
-        _governance_dict(
-            config.mode,
-            config.limit_micros,
-            max_steps,
-            preset=config.governance_preset,
-        ),
-        price,
-        controls,
+    gov_dict = _governance_dict(
+        config.mode,
+        config.limit_micros,
+        max_steps,
+        preset=config.governance_preset,
     )
+    store: Store | None = None
+    if _uses_trajectory_hint(gov_dict):
+        db_path = config.trajectory_db or "benchmarking/browseruse/.trajectory_bench.db"
+        store = _trajectory_store(db_path)
+    governor = build_governor(gov_dict, price, controls, store=store)
     reg = RunRegistration(run_id=run_id, intent="browseruse", user_dims={"user_id": config.user_id})
     span = SpanContext(span_id=f"span-{uuid.uuid4().hex[:8]}", service="browseruse")
     governor.ledger.open_run(run_id)
-    return ActiveRun(config=config, governor=governor, controls=controls, registration=reg, span=span, task=task)
+    if store is not None:
+        store.create_run(
+            RunRecord(
+                run_id=run_id,
+                agent="browseruse",
+                status="running",
+                task=task,
+                started_at=__import__("time").time(),
+                dims={"intent": "browseruse", "user_id": config.user_id},
+            )
+        )
+    return ActiveRun(
+        config=config, governor=governor, controls=controls, registration=reg, span=span,
+        task=task, store=store,
+    )
 
 
 def _agent_llms(agent) -> list[Any]:
@@ -100,6 +129,63 @@ def _agent_llms(agent) -> list[Any]:
     return out
 
 
+def _finalize_trajectory_index(active: ActiveRun, history) -> None:
+    store = active.store
+    if store is None:
+        return
+    run_id = active.registration.run_id
+    import time
+
+    success = history is not None and bool(history.is_successful())
+    halted = active.governor.ledger.is_halted(run_id)
+    rs = active.governor.ledger.runs.get(run_id)
+    status = "completed" if success and not halted else ("halted" if halted else "error")
+    spend = active.governor.ledger.cost_micros(run_id)
+    if history is not None and spend == 0:
+        usage = getattr(history, "usage", None)
+        spend = int(round((getattr(usage, "total_cost", 0.0) or 0.0) * 1_000_000))
+    steps = history.number_of_steps() if history is not None else active.governor.ledger.step_count(run_id)
+    store.update_run(
+        run_id,
+        status=status,
+        halt_reason=rs.halt_reason if rs else None,
+        cost_micros=spend,
+        steps=steps,
+        ended_at=time.time(),
+    )
+    rec = store.get_run(run_id)
+    if rec is None:
+        return
+    hint_params = (_governance_dict(
+        active.config.mode,
+        active.config.limit_micros,
+        100,
+        preset=active.config.governance_preset,
+    ).get("policies") or {}).get("trajectory_hint")
+    if not enqueue_completed_run(
+        store,
+        rec=rec,
+        registration=active.registration,
+        agent="browseruse",
+        window=active.governor.ledger.window(run_id),
+        policy_params=hint_params,
+    ):
+        return
+    if active.config.sync_trajectory_index:
+        hint_params = dict(hint_params or {})
+        store.drain_trajectory_build_queue(
+            max_age_days=int(hint_params.get("max_age_days", 30)),
+            max_entries_per_scope=int(hint_params.get("max_entries_per_scope", 500)),
+        )
+    else:
+        hint_params = dict(hint_params or {})
+        schedule_trajectory_drain(
+            store,
+            max_age_days=int(hint_params.get("max_age_days", 30)),
+            max_entries_per_scope=int(hint_params.get("max_entries_per_scope", 500)),
+        )
+
+
 def _snapshot_metrics(active: ActiveRun, history) -> None:
     run_id = active.registration.run_id
     rs = active.governor.ledger.runs.get(run_id)
@@ -117,6 +203,9 @@ def _snapshot_metrics(active: ActiveRun, history) -> None:
             agent_steps=history.number_of_steps() if history is not None else 0,
             agent_done=history.is_done() if history is not None else False,
             agent_success=history.is_successful() if history is not None else None,
+            trajectory_hint_fired=active.trajectory_hint_fired,
+            trajectory_hint_match=active.trajectory_hint_match,
+            trajectory_hint_chars=active.trajectory_hint_chars,
         )
     )
 
@@ -174,6 +263,7 @@ def install() -> None:
                 history = getattr(self, "history", None)
             raise
         finally:
+            _finalize_trajectory_index(active, history)
             _snapshot_metrics(active, history)
             set_active_run(None)
 
@@ -215,6 +305,8 @@ async def run_governed(
     live_pricing: bool = False,
     max_steps: int = 100,
     governance_preset: str = "steering",
+    trajectory_db: str | None = None,
+    sync_trajectory_index: bool = False,
     on_step_start=None,
     on_step_end=None,
 ) -> GovernedRunResult:
@@ -228,6 +320,8 @@ async def run_governed(
         user_id=user_id,
         live_pricing=live_pricing,
         governance_preset=governance_preset,
+        trajectory_db=trajectory_db,
+        sync_trajectory_index=sync_trajectory_index,
     )
     set_run_config(cfg)
     object.__setattr__(agent, "_tokenops_run_config", cfg)

--- a/benchmarking/browseruse/run_trajectory_hint_bench.py
+++ b/benchmarking/browseruse/run_trajectory_hint_bench.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Live browser-use bench for trajectory_hint: fire rate, SimHash hits, cost delta.
+
+Phases:
+  1. seed   — index a successful run (steering_trajectory)
+  2. matrix — repeat task variants; report hint fire + match type (exact/simhash/miss)
+  3. cost   — steering vs steering_trajectory on hits; report token/cost delta
+
+Example:
+  benchmarking/browseruse/.venv/bin/python benchmarking/browseruse/run_trajectory_hint_bench.py \\
+    --phase all --scenario example_tight_cap --pause-seconds 90
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
+
+from tokenops.env import load_env  # noqa: E402
+
+from benchmarking.browseruse.integration import install, run_governed  # noqa: E402
+from benchmarking.browseruse.scenarios_live import EXAMPLE_TIGHT_CAP, get_scenario  # noqa: E402
+from benchmarking.browseruse.session import GovernedRunMetrics  # noqa: E402
+from benchmarking.common.harness import BenchmarkMode  # noqa: E402
+from tokenops.control.models import RunRegistration  # noqa: E402
+from tokenops.control.store import Store  # noqa: E402
+from tokenops.control.trajectory.scope import (  # noqa: E402
+    input_hash,
+    input_simhash,
+    scope_key,
+    simhash_as_sqlite,
+)
+from tokenops.control.policies._util import hamming  # noqa: E402
+
+DEFAULT_DB = ROOT / "benchmarking" / "browseruse" / ".trajectory_bench.db"
+
+
+@dataclass
+class TaskVariant:
+    id: str
+    task: str
+    note: str = ""
+
+
+@dataclass
+class RunRow:
+    variant_id: str
+    preset: str
+    phase: str
+    metrics: GovernedRunMetrics | None
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+    error: str | None = None
+    offline_match: str | None = None  # predicted from index before run
+
+
+@dataclass
+class BenchReport:
+    scenario_id: str
+    seed: RunRow | None = None
+    matrix: list[RunRow] = field(default_factory=list)
+    cost_pairs: list[dict] = field(default_factory=list)
+
+
+def _task_variants(base_task: str) -> list[TaskVariant]:
+    normalized_words = base_task.split()
+    reorder = " ".join([normalized_words[1], normalized_words[0], *normalized_words[2:]])
+    subtle = f"Please complete this task carefully.\n{base_task}"
+    different = """
+On https://example.com, report only the domain name shown in the browser address bar.
+Call done with success=true. Do not read body text.
+""".strip()
+    return [
+        TaskVariant("exact", base_task, "byte-identical task"),
+        TaskVariant("word_reorder", reorder, "first two words swapped (SimHash probe)"),
+        TaskVariant("subtle_prefix", subtle, "extra preamble (likely miss)"),
+        TaskVariant("different_task", different, "unrelated goal (miss)"),
+    ]
+
+
+def _offline_lookup(store: Store, task: str) -> str | None:
+    reg = RunRegistration(run_id="", intent="browseruse")
+    sk = scope_key(reg, "browseruse", ["intent", "agent"])
+    hit = store.lookup_trajectory_index(
+        scope_key=sk,
+        input_hash=input_hash(task),
+        input_simhash=simhash_as_sqlite(input_simhash(task)),
+        max_age_days=30,
+        simhash_threshold=4,
+    )
+    return hit["match"] if hit else None
+
+
+def _simhash_distance(a: str, b: str) -> int:
+    return hamming(input_simhash(a), input_simhash(b))
+
+
+def _make_agent(task: str):
+    from browser_use import Agent, Browser, ChatOpenAI
+
+    if not os.getenv("OPENAI_API_KEY") and not os.getenv("BROWSER_USE_API_KEY"):
+        raise RuntimeError("Set OPENAI_API_KEY or BROWSER_USE_API_KEY")
+    if os.getenv("BROWSER_USE_API_KEY"):
+        from browser_use import ChatBrowserUse
+
+        llm = ChatBrowserUse()
+        name = "ChatBrowserUse"
+    else:
+        llm = ChatOpenAI(model="gpt-4o-mini")
+        name = "ChatOpenAI(gpt-4o-mini)"
+    browser = Browser(headless=True)
+    agent = Agent(task=task, llm=llm, browser=browser, calculate_cost=True)
+    return agent, name
+
+
+def _usage(history) -> tuple[int, float]:
+    usage = getattr(history, "usage", None) if history else None
+    if usage is None:
+        return 0, 0.0
+    return (
+        int(getattr(usage, "total_tokens", 0) or 0),
+        float(getattr(usage, "total_cost", 0.0) or 0.0),
+    )
+
+
+async def _run_one(
+    *,
+    task: str,
+    preset: str,
+    limit_micros: int,
+    max_steps: int,
+    trajectory_db: str,
+    phase: str,
+    variant_id: str,
+) -> RunRow:
+    agent, llm_name = _make_agent(task)
+    print(f"\n--- {phase} | {variant_id} | {preset} ({llm_name}) ---", flush=True)
+    store = Store(trajectory_db, auto_seed=False)
+    offline = _offline_lookup(store, task) if preset == "steering_trajectory" else None
+    store.close()
+
+    install()
+    result = await run_governed(
+        agent,
+        mode=BenchmarkMode.TOKENOPS,
+        limit_micros=limit_micros,
+        live_pricing=True,
+        max_steps=max_steps,
+        governance_preset=preset,
+        trajectory_db=trajectory_db,
+        sync_trajectory_index=True,
+    )
+    tokens, cost = _usage(result.history)
+    m = result.metrics
+    row = RunRow(
+        variant_id=variant_id,
+        preset=preset,
+        phase=phase,
+        metrics=m,
+        total_tokens=tokens,
+        cost_usd=cost or (m.spend_micros / 1_000_000 if m else 0.0),
+        error=result.error,
+        offline_match=offline,
+    )
+    if m:
+        print(
+            f"  cost=${row.cost_usd:.4f} tokens={tokens:,} steps={m.agent_steps} "
+            f"success={m.agent_success} halted={m.halted}",
+            flush=True,
+        )
+        print(
+            f"  hint: fired={m.trajectory_hint_fired} match={m.trajectory_hint_match} "
+            f"chars={m.trajectory_hint_chars} offline_predicted={offline}",
+            flush=True,
+        )
+    if result.error:
+        print(f"  error: {result.error}", flush=True)
+    return row
+
+
+async def _pause_between_runs(seconds: float, *, before: str) -> None:
+    if seconds <= 0:
+        return
+    print(f"  pausing {seconds:.0f}s before {before} (rate-limit cushion)...", flush=True)
+    await asyncio.sleep(seconds)
+
+
+async def run_bench(
+    *,
+    scenario_id: str,
+    trajectory_db: str,
+    phase: str,
+    limit_usd: float | None,
+    max_steps: int | None,
+    pause_seconds: float,
+) -> BenchReport:
+    scenario = get_scenario(scenario_id)
+    limit_micros = int(round((limit_usd or scenario.default_limit_usd) * 1_000_000))
+    max_steps = max_steps or scenario.default_max_steps
+    base_task = scenario.task.strip()
+    variants = _task_variants(base_task)
+
+    print(f"Scenario: {scenario.id}  cap=${limit_micros/1e6:.2f}  max_steps={max_steps}")
+    print(f"Trajectory DB: {trajectory_db}")
+    for v in variants:
+        if v.id == "exact":
+            continue
+        print(f"  simhash dist vs exact [{v.id}]: {_simhash_distance(base_task, v.task)}")
+
+    report = BenchReport(scenario_id=scenario.id)
+
+    if phase in ("all", "seed", "cost"):
+        print("\n== SEED (index builder) ==")
+        report.seed = await _run_one(
+            task=base_task,
+            preset="steering_trajectory",
+            limit_micros=limit_micros,
+            max_steps=max_steps,
+            trajectory_db=trajectory_db,
+            phase="seed",
+            variant_id="exact",
+        )
+        if not report.seed.metrics or not report.seed.metrics.agent_success:
+            print("WARNING: seed run did not succeed — index may be empty", flush=True)
+        if phase in ("all", "matrix"):
+            await _pause_between_runs(pause_seconds, before="hit-rate matrix")
+
+    if phase in ("all", "matrix"):
+        print("\n== HIT-RATE MATRIX (steering_trajectory) ==")
+        matrix_variants = [v for v in variants if not (phase == "matrix" and v.id == "exact")]
+        for i, v in enumerate(matrix_variants):
+            if i > 0:
+                await _pause_between_runs(pause_seconds, before=f"matrix | {v.id}")
+            row = await _run_one(
+                task=v.task,
+                preset="steering_trajectory",
+                limit_micros=limit_micros,
+                max_steps=max_steps,
+                trajectory_db=trajectory_db,
+                phase="matrix",
+                variant_id=v.id,
+            )
+            report.matrix.append(row)
+        if phase in ("all", "cost"):
+            await _pause_between_runs(pause_seconds, before="cost delta")
+
+    if phase in ("all", "cost"):
+        print("\n== COST DELTA (steering vs steering_trajectory on exact repeat) ==")
+        baseline = await _run_one(
+            task=base_task,
+            preset="steering",
+            limit_micros=limit_micros,
+            max_steps=max_steps,
+            trajectory_db=trajectory_db,
+            phase="cost_baseline",
+            variant_id="exact",
+        )
+        await _pause_between_runs(pause_seconds, before="cost_hinted")
+        hinted = await _run_one(
+            task=base_task,
+            preset="steering_trajectory",
+            limit_micros=limit_micros,
+            max_steps=max_steps,
+            trajectory_db=trajectory_db,
+            phase="cost_hinted",
+            variant_id="exact",
+        )
+        if baseline.metrics and hinted.metrics:
+            b_cost, h_cost = baseline.cost_usd, hinted.cost_usd
+            b_tok, h_tok = baseline.total_tokens, hinted.total_tokens
+            pct = round(100 * (b_cost - h_cost) / b_cost, 2) if b_cost > 0 else 0.0
+            report.cost_pairs.append({
+                "variant": "exact",
+                "baseline_cost_usd": b_cost,
+                "hinted_cost_usd": h_cost,
+                "cost_delta_pct": pct,
+                "baseline_tokens": b_tok,
+                "hinted_tokens": h_tok,
+                "hint_fired": hinted.metrics.trajectory_hint_fired,
+                "hint_match": hinted.metrics.trajectory_hint_match,
+            })
+
+    return report
+
+
+def _summarize(report: BenchReport) -> dict:
+    matrix = []
+    for r in report.matrix:
+        m = r.metrics
+        matrix.append({
+            "variant": r.variant_id,
+            "offline_predicted": r.offline_match,
+            "hint_fired": m.trajectory_hint_fired if m else False,
+            "hint_match": m.trajectory_hint_match if m else None,
+            "cost_usd": r.cost_usd,
+            "tokens": r.total_tokens,
+            "success": m.agent_success if m else False,
+        })
+
+    fired = [x for x in matrix if x["hint_fired"]]
+    return {
+        "scenario": report.scenario_id,
+        "seed_success": report.seed.metrics.agent_success if report.seed and report.seed.metrics else None,
+        "matrix": matrix,
+        "hit_rate": len(fired) / len(matrix) if matrix else 0.0,
+        "exact_hits": sum(1 for x in matrix if x["hint_match"] == "exact"),
+        "simhash_hits": sum(1 for x in matrix if x["hint_match"] == "simhash"),
+        "cost_pairs": report.cost_pairs,
+    }
+
+
+def main() -> None:
+    load_env()
+    p = argparse.ArgumentParser(description="Trajectory hint browser-use live bench")
+    p.add_argument("--scenario", default=EXAMPLE_TIGHT_CAP.id)
+    p.add_argument("--phase", choices=["all", "seed", "matrix", "cost"], default="all")
+    p.add_argument("--trajectory-db", default=str(DEFAULT_DB))
+    p.add_argument("--limit-usd", type=float, default=None)
+    p.add_argument("--max-steps", type=int, default=None)
+    p.add_argument("--fresh-db", action="store_true", help="Delete trajectory DB before run")
+    p.add_argument(
+        "--pause-seconds",
+        type=float,
+        default=90.0,
+        help="Seconds to wait between runs (TPM rate-limit cushion; default 90)",
+    )
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    if args.fresh_db and Path(args.trajectory_db).exists():
+        Path(args.trajectory_db).unlink()
+
+    report = asyncio.run(
+        run_bench(
+            scenario_id=args.scenario,
+            trajectory_db=args.trajectory_db,
+            phase=args.phase,
+            limit_usd=args.limit_usd,
+            max_steps=args.max_steps,
+            pause_seconds=args.pause_seconds,
+        )
+    )
+    summary = _summarize(report)
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print("\n== SUMMARY ==")
+        print(f"seed_success: {summary['seed_success']}")
+        print(f"hit_rate: {summary['hit_rate']:.0%} ({len([x for x in summary['matrix'] if x['hint_fired']])}/{len(summary['matrix'])})")
+        print(f"exact_hits: {summary['exact_hits']}  simhash_hits: {summary['simhash_hits']}")
+        for row in summary["matrix"]:
+            print(
+                f"  {row['variant']:16} offline={row['offline_predicted']} "
+                f"fired={row['hint_fired']} match={row['hint_match']} "
+                f"${row['cost_usd']:.4f} {row['tokens']:,} tok"
+            )
+        for pair in summary["cost_pairs"]:
+            print(
+                f"cost delta [{pair['variant']}]: baseline=${pair['baseline_cost_usd']:.4f} "
+                f"hinted=${pair['hinted_cost_usd']:.4f} ({pair['cost_delta_pct']:+.1f}%) "
+                f"hint_fired={pair['hint_fired']} match={pair['hint_match']}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/browseruse/session.py
+++ b/benchmarking/browseruse/session.py
@@ -20,6 +20,8 @@ class RunConfig:
     user_id: str = "browseruse-bench"
     live_pricing: bool = False
     governance_preset: str = "steering"
+    trajectory_db: str | None = None
+    sync_trajectory_index: bool = False
 
 
 @dataclass
@@ -31,6 +33,11 @@ class ActiveRun:
     span: SpanContext
     task: str = ""
     main_llm_id: int | None = None
+    store: object | None = None  # tokenops.control.store.Store when trajectory_hint enabled
+    trajectory_hint_fired: bool = False
+    trajectory_hint_match: str | None = None
+    trajectory_hint_chars: int = 0
+    _main_llm_calls: int = 0
 
 
 _run_config: ContextVar[RunConfig | None] = ContextVar("browseruse_run_config", default=None)
@@ -63,6 +70,9 @@ class GovernedRunMetrics:
     agent_steps: int
     agent_done: bool
     agent_success: bool | None
+    trajectory_hint_fired: bool = False
+    trajectory_hint_match: str | None = None
+    trajectory_hint_chars: int = 0
 
 
 _last_metrics: GovernedRunMetrics | None = None

--- a/benchmarking/metagpt/README.md
+++ b/benchmarking/metagpt/README.md
@@ -59,10 +59,12 @@ Most MetaGPT runs are **sub‑cent**. Good for proving the adapter and steer pat
 
 Browser-use runner has full trial tags and `showcase_pass`. MetaGPT runner reports spend, steps, and optional evaluation oracles — treat **`aspirational_failures`** in evaluation as hints, not requirements that a policy fired.
 
+Full protocol (multi-run sweeps, infra exclusion, aggregation): [../README.md#benchmarking-process](../README.md#benchmarking-process).
+
 For multi-trial comparison:
 
 ```bash
-python benchmarking/run_trials_sweep.py --framework metagpt --scenario pricing_quick_verify_trap --trial-counts 1,5,10 --cooldown-sec 120
+python benchmarking/run_trials_sweep.py --framework metagpt --scenario pricing_quick_verify_trap --trial-counts 1,3,5 --cooldown-sec 120
 ```
 
 ## What we claim in a demo

--- a/docs/policies/trajectory_hint.md
+++ b/docs/policies/trajectory_hint.md
@@ -1,0 +1,145 @@
+# trajectory_hint — warm-start INJECT from prior successful runs
+
+Companion to the policies LLD and ``controls.md``. **Opt-in — disabled by default.**
+
+Code: ``src/tokenops/control/policies/trajectory_hint.py``
+Tests: ``tests/test_trajectory_hint.py``
+Bench: ``benchmarking/browseruse/run_trajectory_hint_bench.py``
+
+---
+
+## TL;DR
+
+On the **first primary-agent LLM call** of a run, lookup prior successful runs with a similar
+first-line task (exact hash + SimHash) within a configured **scope**. If matched, **INJECT** a
+compressed playbook — tool order, cost, pitfalls — as a final user turn. Never HALTs.
+
+Index rows are built **in the background** after run close (enqueue on the response path,
+compress in a daemon drain worker).
+
+**Not in ``default.yaml``.** ``build()`` defaults ``enabled: false``; enable only when you
+have a Store and accept Phase 1 limitations below.
+
+## Detect (formula)
+
+```
+pre_call AND (primary_agent_turn OR steps == 0) AND NOT halted
+lookup(scope_key, normalize(task)) within max_age_days:
+  T1: input_hash exact match
+  T2: SimHash hamming ≤ threshold
+skip inject if indexed step_count < min_index_steps
+```
+
+## Scope key
+
+```
+scope_key = sorted join of dim=value for each configured scope_dim:
+  intent  → RunRegistration.intent
+  agent   → boundary service
+  <tag>   → RunRegistration.user_dims[<tag>] or "_none"
+```
+
+Default ``scope_dims: [intent, agent]``. No hardcoded tenant.
+
+## Index write (structural gates)
+
+Enqueued at run close when ``enabled: true`` and all pass:
+
+- ``status == completed``
+- ``halt_reason`` is null
+- ``steps >= min_steps``
+- ``cost_micros > 0``
+- normalized task length ≥ ``min_input_chars``
+
+**Phase 2:** ``quality_score`` / constraint-adherence hook — see Learnings.
+
+## Action — INJECT once
+
+Hint is pinned during ``context_compaction`` (same as ``progress_guard`` corrections).
+
+**Injection gate:** skip if indexed ``step_count < min_index_steps`` (default 4) — short
+trajectories rarely benefit from hint overhead.
+
+**Tiered format** (from indexed step count):
+
+| Tier | Steps | Payload |
+|------|-------|---------|
+| ``sequence_only`` | ≤ ``sequence_only_max_steps`` (6) | tool path only |
+| ``sequence_plus_pitfalls`` | ≤ ``sequence_plus_pitfalls_max_steps`` (12) | path + brief pitfalls |
+| ``full`` | > 12 | path + step summary + pitfalls |
+
+## Config (all required when enabled)
+
+```yaml
+trajectory_hint:
+  enabled: false              # opt-in — must be true to activate
+  scope_dims: [intent, agent]
+  max_age_days: 30            # mandatory
+  max_entries_per_scope: 500
+  simhash_threshold: 4
+  min_steps: 2                # index write gate
+  min_index_steps: 4          # inject gate (indexed step count)
+  sequence_only_max_steps: 6
+  sequence_plus_pitfalls_max_steps: 12
+  min_input_chars: 10
+  hint_max_chars: 1600
+```
+
+Requires ``store=`` in ``build_governor``.
+
+Enable for browser-use benches via ``tokenops_config_steering_trajectory`` (sets
+``enabled: true``).
+
+## Learnings (live bench, Phase 1)
+
+### When hints help vs hurt
+
+| Scenario | Indexed steps | Hint fired? | Cost delta vs steering |
+|----------|---------------|-------------|------------------------|
+| ``example_tight_cap`` | 2 | No (``min_index_steps``) | ~0% — correct skip |
+| ``books_pagination_stress`` | 7–21 | Yes (exact / simhash) | Often **negative** — hint did not shorten runs |
+
+**Takeaway:** matching + injecting is not enough. Cost savings require trajectories long enough
+to repay hint tokens *and* playbooks that encode constraint-faithful behavior.
+
+### Short trajectories — skip inject
+
+``min_index_steps: 4`` prevents firing on 2-step tasks where hint overhead dominates
+(``example_tight_cap``: prior +0.3% cost with hint; after gate, 0% delta).
+
+### Tiered payload — right-size hint
+
+``format_hint`` tiers reduce payload on medium paths (``sequence_only`` / ``sequence_plus_pitfalls``).
+Full tier (up to ``hint_max_chars``) only when indexed steps > 12.
+
+### Structural gates are insufficient — bad playbooks mislead
+
+Index writes gate on **structure only** (completed, min steps, min input length). A run can
+``success=true`` while violating task constraints (e.g. skip required pagination).
+
+On ``books_pagination_stress`` with 120s inter-run pauses:
+
+- Baseline (steering): **5 steps**, ~$0.049, no hint.
+- Hinted repeat: **11 steps**, ~$0.122, judge **FAIL** — agent followed a misleading playbook,
+  clicked unrelated links, reported false success.
+
+**Root cause:** hint is guidance-only; a low-quality indexed path increases overconfidence and
+thrashing, not speed.
+
+**Phase 2 mitigations (not implemented):**
+
+- ``quality_score`` hook on index enqueue (bench judge, verifier, or constraint checks).
+- Require evidence of required tool sequence in the compressed window (e.g. sequential pagination).
+- Optional mid-run re-hint when ``live_steps > index_steps * 1.25``.
+
+### Bench hygiene — rate limits
+
+Back-to-back browser runs exhaust OpenAI TPM (429s). Use
+``run_trajectory_hint_bench.py --pause-seconds 90`` (or 120 for heavy scenarios). Default is
+90s between all phases (seed → matrix → cost).
+
+## Status
+
+✅ Phase 1 implemented (lookup, inject, background index, ``min_index_steps``, tiered hint).
+
+⏳ Phase 2 deferred: quality gate, constraint-aware indexing, reliable cost savings proof.

--- a/src/tokenops/agents/research/native/server.py
+++ b/src/tokenops/agents/research/native/server.py
@@ -28,6 +28,7 @@ from tokenops.control.context import RUN_ID_HEADER, current_registration, curren
 from tokenops.control.engine import Throttled
 from tokenops.control.ledger import LIFETIME
 from tokenops.control.models import RunNotRegisteredError, RunRecord
+from tokenops.control.trajectory import enqueue_completed_run, schedule_trajectory_drain
 from tokenops.control.pricing import build_price_book
 from tokenops.control.store import Store
 from tokenops.providers import complete, stream_complete
@@ -146,6 +147,24 @@ def build_app():
                         steps=governor.ledger.step_count(run_id),
                         ended_at=time.time(),
                     )
+                    rec = store.get_run(run_id)
+                    if rec is not None:
+                        gov_cfg = store.governance_config_for(AGENT).get("governance", {})
+                        hint_params = (gov_cfg.get("policies") or {}).get("trajectory_hint")
+                        if enqueue_completed_run(
+                            store,
+                            rec=rec,
+                            registration=reg,
+                            agent=AGENT,
+                            window=governor.ledger.window(run_id),
+                            policy_params=hint_params,
+                        ):
+                            p = dict(hint_params or {})
+                            schedule_trajectory_drain(
+                                store,
+                                max_age_days=int(p.get("max_age_days", 30)),
+                                max_entries_per_scope=int(p.get("max_entries_per_scope", 500)),
+                            )
 
             result = RunResult(findings=findings, summary=summary, steps=steps, token_usage=token_usage)
             response = task_response(result)

--- a/src/tokenops/control/config.py
+++ b/src/tokenops/control/config.py
@@ -129,9 +129,17 @@ def build_governor(
     ctx = _Ctx(budgets=budgets, price=price)
 
     for name, params in (gov_cfg.get("policies") or {}).items():
-        if name not in _TEMPLATES:
+        if name not in _TEMPLATES and name != "trajectory_hint":
             raise ValueError(f"unknown policy {name!r}; known: {sorted(_TEMPLATES)}")
-        detector, policy = _TEMPLATES[name](params or {}, ctx)
+        if name == "trajectory_hint":
+            # Opt-in only: excluded from default.yaml; build() defaults enabled=False.
+            if store is None:
+                raise ValueError("trajectory_hint requires store=... in build_governor")
+            from tokenops.control.policies.trajectory_hint import build as build_trajectory_hint
+
+            detector, policy = build_trajectory_hint(store, **(params or {}))
+        else:
+            detector, policy = _TEMPLATES[name](params or {}, ctx)
         governor.register(detector, policy)
 
     return governor

--- a/src/tokenops/control/core.py
+++ b/src/tokenops/control/core.py
@@ -165,6 +165,7 @@ class CallRequest:
     model: str
     estimated_input_tokens: int = 0
     max_output_tokens: int | None = None
+    primary_agent_turn: bool = False  # first main-agent LLM turn (browser-use aux LLMs may precede)
 
 
 # =========================================================================== #

--- a/src/tokenops/control/integration.py
+++ b/src/tokenops/control/integration.py
@@ -182,6 +182,9 @@ def _compact_messages(messages):
         if role == "system":
             out.append(msg)
             continue
+        if isinstance(content, str) and content.startswith("[TokenOps trajectory hint"):
+            out.append(msg)
+            continue
         key = (role, content)
         if key in seen:
             continue

--- a/src/tokenops/control/policies/trajectory_hint.py
+++ b/src/tokenops/control/policies/trajectory_hint.py
@@ -1,0 +1,254 @@
+"""trajectory_hint — warm-start INJECT from prior successful runs. Opt-in; requires Store.
+
+LLD row:
+    Detect: pre_call at step 0; lookup (scope_key, input_hash) with SimHash fallback within
+            max_age_days.
+    Fix:    INJECT a compressed playbook from the best prior run. Edge-trigger once per run.
+            Never HALT.
+
+Index writes are enqueued at run close and built by a background drain worker — not on the
+hot path.
+
+**Default: disabled.** Not in ``default.yaml`` or ``_TEMPLATES``; must pass ``enabled: true``
+explicitly (e.g. ``steering_trajectory`` bench preset). See ``docs/policies/trajectory_hint.md``.
+
+Bench learnings (Phase 1):
+    - Short trajectories: ``min_index_steps`` skips inject when indexed path is too short to
+      repay hint overhead (e.g. 2-step example.com → no hint, ~0% cost delta).
+    - Tiered ``format_hint``: scale payload by indexed step count; full tier only for long paths.
+    - Structural index gates are insufficient: a ``completed`` run can encode a playbook that
+      violates task constraints; injecting it can mislead the agent (longer runs, higher cost).
+    - Quality / constraint-adherence hook for index writes is Phase 2 — do not expect reliable
+      cost savings until then.
+    - Live benches: use ``--pause-seconds`` (90s+) between runs to avoid OpenAI TPM 429s.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from tokenops.control.core import (
+    Action,
+    ActionKind,
+    CallRequest,
+    Detector,
+    LedgerView,
+    Policy,
+    Severity,
+    Signal,
+)
+from tokenops.control.models import RunRegistration
+from tokenops.control.trajectory.hint import TrajectoryHit, format_hint, hint_tier_for
+from tokenops.control.trajectory.scope import (
+    input_hash,
+    input_simhash,
+    normalize_input,
+    scope_key,
+    simhash_as_sqlite,
+    simhash_from_sqlite,
+)
+
+if TYPE_CHECKING:
+    from tokenops.control.store import Store
+
+
+class TrajectoryHintDetector(Detector):
+    name = "trajectory_hint"
+
+    def __init__(
+        self,
+        store: Store,
+        *,
+        scope_dims: Sequence[str],
+        max_age_days: int,
+        simhash_threshold: int,
+        hint_max_chars: int,
+        min_index_steps: int = 4,
+        sequence_only_max_steps: int = 6,
+        sequence_plus_pitfalls_max_steps: int = 12,
+        enabled: bool = True,
+    ) -> None:
+        self._store = store
+        self.scope_dims = list(scope_dims)
+        self.max_age_days = max_age_days
+        self.simhash_threshold = simhash_threshold
+        self.hint_max_chars = hint_max_chars
+        self.min_index_steps = min_index_steps
+        self.sequence_only_max_steps = sequence_only_max_steps
+        self.sequence_plus_pitfalls_max_steps = sequence_plus_pitfalls_max_steps
+        self.enabled = enabled
+        self._injected: set[str] = set()
+
+    def reset(self, run_id: str) -> None:
+        self._injected.discard(run_id)
+
+    def _registration(self, request: CallRequest) -> RunRegistration:
+        tags = dict(request.attr.tags)
+        intent = tags.pop("intent", "")
+        return RunRegistration(
+            run_id=request.attr.run_id,
+            intent=intent,
+            user_dims={k: v for k, v in tags.items() if k != "intent"},
+        )
+
+    def _task_text(self, run_id: str) -> str:
+        rec = self._store.get_run(run_id)
+        if rec and rec.task:
+            return rec.task
+        return ""
+
+    def pre_call(self, request: CallRequest, view: LedgerView) -> Signal | None:
+        if not self.enabled:
+            return None
+        run_id = request.attr.run_id
+        if run_id in self._injected:
+            return None
+        if not request.primary_agent_turn and view.step_count(run_id) != 0:
+            return None
+        if view.is_halted(run_id):
+            return None
+
+        task = self._task_text(run_id)
+        if not task or len(normalize_input(task)) < 10:
+            return None
+
+        reg = self._registration(request)
+        sk = scope_key(reg, request.attr.agent, self.scope_dims)
+        query_hash = input_hash(task)
+        query_simhash = input_simhash(task)
+
+        raw = self._store.lookup_trajectory_index(
+            scope_key=sk,
+            input_hash=query_hash,
+            input_simhash=simhash_as_sqlite(query_simhash),
+            max_age_days=self.max_age_days,
+            simhash_threshold=self.simhash_threshold,
+        )
+        if raw is None:
+            return None
+
+        hit = TrajectoryHit(
+            source_run_id=raw["source_run_id"],
+            step_count=raw["step_count"],
+            cost_micros=raw["cost_micros"],
+            tool_sequence=raw["tool_sequence"],
+            step_summary=raw["step_summary"],
+            match=raw["match"],
+        )
+        if hit.step_count < self.min_index_steps:
+            return None
+
+        tier = hint_tier_for(
+            hit.step_count,
+            sequence_only_max_steps=self.sequence_only_max_steps,
+            sequence_plus_pitfalls_max_steps=self.sequence_plus_pitfalls_max_steps,
+        )
+
+        self._injected.add(run_id)
+        return Signal(
+            detector=self.name,
+            severity=Severity.WARN,
+            run_id=run_id,
+            reason=f"trajectory hint from {hit.source_run_id} ({hit.match} match, tier={tier})",
+            evidence={
+                "scope_key": sk,
+                "source_run_id": hit.source_run_id,
+                "step_count": hit.step_count,
+                "cost_micros": hit.cost_micros,
+                "tool_sequence": hit.tool_sequence,
+                "step_summary": hit.step_summary,
+                "match": hit.match,
+                "hint_tier": tier,
+            },
+        )
+
+
+class TrajectoryHintPolicy(Policy):
+    name = "trajectory_hint"
+
+    def __init__(
+        self,
+        *,
+        hint_max_chars: int = 1600,
+        sequence_only_max_steps: int = 6,
+        sequence_plus_pitfalls_max_steps: int = 12,
+    ) -> None:
+        self.hint_max_chars = hint_max_chars
+        self.sequence_only_max_steps = sequence_only_max_steps
+        self.sequence_plus_pitfalls_max_steps = sequence_plus_pitfalls_max_steps
+
+    def decide(self, signal: Signal, view: LedgerView) -> Action:
+        ev = signal.evidence
+        hit = TrajectoryHit(
+            source_run_id=str(ev.get("source_run_id", "")),
+            step_count=int(ev.get("step_count", 0)),
+            cost_micros=int(ev.get("cost_micros", 0)),
+            tool_sequence=str(ev.get("tool_sequence", "")),
+            step_summary=str(ev.get("step_summary", "")),
+            match=str(ev.get("match", "exact")),
+        )
+        tier = str(ev.get("hint_tier", "full"))
+        return Action(
+            kind=ActionKind.INJECT,
+            run_id=signal.run_id,
+            reason=signal.reason,
+            inject_message=format_hint(
+                hit,
+                tier=tier if tier in ("sequence_only", "sequence_plus_pitfalls", "full") else None,
+                max_chars=self.hint_max_chars,
+                sequence_only_max_steps=self.sequence_only_max_steps,
+                sequence_plus_pitfalls_max_steps=self.sequence_plus_pitfalls_max_steps,
+            ),
+        )
+
+
+def build(
+    store: Store,
+    *,
+    enabled: bool = False,
+    scope_dims: Sequence[str] | None = None,
+    max_age_days: int = 30,
+    max_entries_per_scope: int = 500,
+    simhash_threshold: int = 4,
+    min_steps: int = 2,
+    min_input_chars: int = 10,
+    min_index_steps: int = 4,
+    sequence_only_max_steps: int = 6,
+    sequence_plus_pitfalls_max_steps: int = 12,
+    hint_max_chars: int = 1600,
+    require_scope: bool = False,
+) -> tuple[Detector, Policy]:
+    if max_age_days <= 0:
+        raise ValueError("trajectory_hint.max_age_days is required and must be > 0")
+    dims = list(scope_dims or ["intent", "agent"])
+    detector = TrajectoryHintDetector(
+        store,
+        scope_dims=dims,
+        max_age_days=max_age_days,
+        simhash_threshold=simhash_threshold,
+        hint_max_chars=hint_max_chars,
+        min_index_steps=min_index_steps,
+        sequence_only_max_steps=sequence_only_max_steps,
+        sequence_plus_pitfalls_max_steps=sequence_plus_pitfalls_max_steps,
+        enabled=enabled,
+    )
+    policy = TrajectoryHintPolicy(
+        hint_max_chars=hint_max_chars,
+        sequence_only_max_steps=sequence_only_max_steps,
+        sequence_plus_pitfalls_max_steps=sequence_plus_pitfalls_max_steps,
+    )
+    detector._index_params = {  # type: ignore[attr-defined]
+        "enabled": enabled,
+        "scope_dims": dims,
+        "max_age_days": max_age_days,
+        "max_entries_per_scope": max_entries_per_scope,
+        "simhash_threshold": simhash_threshold,
+        "min_steps": min_steps,
+        "min_input_chars": min_input_chars,
+        "min_index_steps": min_index_steps,
+        "sequence_only_max_steps": sequence_only_max_steps,
+        "sequence_plus_pitfalls_max_steps": sequence_plus_pitfalls_max_steps,
+        "require_scope": require_scope,
+        "hint_max_chars": hint_max_chars,
+    }
+    return detector, policy

--- a/src/tokenops/control/store.py
+++ b/src/tokenops/control/store.py
@@ -17,9 +17,8 @@ import os
 import sqlite3
 import time
 import uuid
-from typing import Sequence
+from typing import Any, Sequence
 
-from tokenops.control.config import _TEMPLATES
 from tokenops.control.models import (
     BudgetSpec,
     PolicyInstance,
@@ -29,6 +28,12 @@ from tokenops.control.models import (
     RunRegistration,
     Segment,
 )
+
+def _known_policy_templates() -> frozenset[str]:
+    from tokenops.control.config import _TEMPLATES
+
+    return frozenset({*_TEMPLATES, "trajectory_hint"})
+
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS segments (
@@ -71,6 +76,39 @@ CREATE TABLE IF NOT EXISTS ledger_halt (
   run_id TEXT PRIMARY KEY,
   halted INTEGER NOT NULL DEFAULT 0,
   halt_reason TEXT
+);
+CREATE TABLE IF NOT EXISTS trajectory_index (
+  id TEXT PRIMARY KEY,
+  scope_key TEXT NOT NULL,
+  input_hash TEXT NOT NULL,
+  input_simhash INTEGER NOT NULL,
+  input_preview TEXT NOT NULL,
+  source_run_id TEXT NOT NULL,
+  step_summary TEXT NOT NULL,
+  tool_sequence TEXT NOT NULL,
+  cost_micros INTEGER NOT NULL,
+  step_count INTEGER NOT NULL,
+  quality_score REAL,
+  indexed_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_traj_scope_hash ON trajectory_index(scope_key, input_hash);
+CREATE INDEX IF NOT EXISTS idx_traj_scope_time ON trajectory_index(scope_key, indexed_at DESC);
+CREATE TABLE IF NOT EXISTS trajectory_build_queue (
+  run_id TEXT PRIMARY KEY,
+  scope_key TEXT NOT NULL,
+  input_hash TEXT NOT NULL,
+  input_simhash INTEGER NOT NULL,
+  input_preview TEXT NOT NULL,
+  task_text TEXT NOT NULL,
+  cost_micros INTEGER NOT NULL,
+  step_count INTEGER NOT NULL,
+  enqueued_at REAL NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS run_trajectory_snapshots (
+  run_id TEXT PRIMARY KEY,
+  window_json TEXT NOT NULL,
+  saved_at REAL NOT NULL
 );
 """
 
@@ -148,8 +186,10 @@ class Store:
     # ---- policy instances ------------------------------------------------- #
 
     def upsert_policy_instance(self, pi: PolicyInstance) -> PolicyInstance:
-        if pi.template not in _TEMPLATES:  # fail closed — same rule as build_governor
-            raise ValueError(f"unknown policy template {pi.template!r}; known: {sorted(_TEMPLATES)}")
+        if pi.template not in _known_policy_templates():  # fail closed — same rule as build_governor
+            raise ValueError(
+                f"unknown policy template {pi.template!r}; known: {sorted(_known_policy_templates())}"
+            )
         self._db.execute(
             "REPLACE INTO policy_instances(id, template, params, agent, budget_id, segment_id, enabled) "
             "VALUES (?,?,?,?,?,?,?)",
@@ -413,6 +453,198 @@ class Store:
             (run_id,),
         )
         self._db.commit()
+
+    # ---- trajectory hint index -------------------------------------------- #
+
+    def save_trajectory_snapshot(self, run_id: str, window_json: str) -> None:
+        self._db.execute(
+            "REPLACE INTO run_trajectory_snapshots(run_id, window_json, saved_at) VALUES (?,?,?)",
+            (run_id, window_json, time.time()),
+        )
+        self._db.commit()
+
+    def enqueue_trajectory_build(
+        self,
+        *,
+        run_id: str,
+        scope_key: str,
+        input_hash: str,
+        input_simhash: int,
+        input_preview: str,
+        task_text: str,
+        cost_micros: int,
+        step_count: int,
+    ) -> None:
+        self._db.execute(
+            "REPLACE INTO trajectory_build_queue("
+            "run_id, scope_key, input_hash, input_simhash, input_preview, task_text, "
+            "cost_micros, step_count, enqueued_at, attempts"
+            ") VALUES (?,?,?,?,?,?,?,?,?,0)",
+            (
+                run_id, scope_key, input_hash, input_simhash, input_preview, task_text,
+                cost_micros, step_count, time.time(),
+            ),
+        )
+        self._db.commit()
+
+    def drain_trajectory_build_queue(
+        self, *, limit: int = 8, max_age_days: int = 30, max_entries_per_scope: int = 500,
+    ) -> int:
+        from tokenops.control.trajectory.compress import compress_trajectory
+        from tokenops.control.trajectory.serialize import window_from_json
+
+        rows = self._db.execute(
+            "SELECT * FROM trajectory_build_queue ORDER BY enqueued_at ASC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        done = 0
+        for row in rows:
+            run_id = row["run_id"]
+            try:
+                snap = self._db.execute(
+                    "SELECT window_json FROM run_trajectory_snapshots WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if not snap:
+                    self._db.execute("DELETE FROM trajectory_build_queue WHERE run_id=?", (run_id,))
+                    self._db.commit()
+                    continue
+                steps = window_from_json(snap["window_json"])
+                step_summary, tool_sequence = compress_trajectory(steps)
+                self._insert_trajectory_index(
+                    scope_key=row["scope_key"],
+                    input_hash=row["input_hash"],
+                    input_simhash=int(row["input_simhash"]),
+                    input_preview=row["input_preview"],
+                    source_run_id=run_id,
+                    step_summary=step_summary,
+                    tool_sequence=tool_sequence,
+                    cost_micros=int(row["cost_micros"]),
+                    step_count=int(row["step_count"]),
+                    max_age_days=max_age_days,
+                    max_entries_per_scope=max_entries_per_scope,
+                )
+                self._db.execute("DELETE FROM trajectory_build_queue WHERE run_id=?", (run_id,))
+                self._db.commit()
+                done += 1
+            except Exception:
+                self._db.execute(
+                    "UPDATE trajectory_build_queue SET attempts = attempts + 1 WHERE run_id=?",
+                    (run_id,),
+                )
+                self._db.commit()
+        return done
+
+    def _insert_trajectory_index(
+        self,
+        *,
+        scope_key: str,
+        input_hash: str,
+        input_simhash: int,
+        input_preview: str,
+        source_run_id: str,
+        step_summary: str,
+        tool_sequence: str,
+        cost_micros: int,
+        step_count: int,
+        quality_score: float | None = None,
+        max_age_days: int = 30,
+        max_entries_per_scope: int = 500,
+    ) -> None:
+        indexed_at = time.time()
+        row_id = new_id("traj")
+        self._db.execute(
+            "INSERT INTO trajectory_index("
+            "id, scope_key, input_hash, input_simhash, input_preview, source_run_id, "
+            "step_summary, tool_sequence, cost_micros, step_count, quality_score, indexed_at"
+            ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                row_id, scope_key, input_hash, input_simhash, input_preview, source_run_id,
+                step_summary, tool_sequence, cost_micros, step_count, quality_score, indexed_at,
+            ),
+        )
+        self._prune_trajectory_scope(scope_key, max_age_days=max_age_days, max_entries=max_entries_per_scope)
+        self._db.commit()
+
+    def _prune_trajectory_scope(
+        self, scope_key: str, *, max_age_days: int, max_entries: int,
+    ) -> None:
+        cutoff = time.time() - max_age_days * 86400
+        self._db.execute(
+            "DELETE FROM trajectory_index WHERE scope_key=? AND indexed_at < ?",
+            (scope_key, cutoff),
+        )
+        count = self._db.execute(
+            "SELECT COUNT(*) FROM trajectory_index WHERE scope_key=?", (scope_key,),
+        ).fetchone()[0]
+        overflow = int(count) - max_entries
+        if overflow > 0:
+            self._db.execute(
+                "DELETE FROM trajectory_index WHERE id IN ("
+                "  SELECT id FROM trajectory_index WHERE scope_key=?"
+                "  ORDER BY COALESCE(quality_score, 0) ASC, cost_micros DESC, indexed_at ASC"
+                "  LIMIT ?"
+                ")",
+                (scope_key, overflow),
+            )
+
+    def lookup_trajectory_index(
+        self,
+        *,
+        scope_key: str,
+        input_hash: str,
+        input_simhash: int,
+        max_age_days: int,
+        simhash_threshold: int,
+    ) -> dict[str, Any] | None:
+        from tokenops.control.policies._util import hamming
+        from tokenops.control.trajectory.scope import simhash_from_sqlite
+
+        cutoff = time.time() - max_age_days * 86400
+        query_fp = simhash_from_sqlite(input_simhash)
+        exact = self._db.execute(
+            "SELECT * FROM trajectory_index "
+            "WHERE scope_key=? AND input_hash=? AND indexed_at >= ? "
+            "ORDER BY COALESCE(quality_score, 0) DESC, cost_micros ASC, indexed_at DESC "
+            "LIMIT 1",
+            (scope_key, input_hash, cutoff),
+        ).fetchone()
+        if exact:
+            return self._trajectory_hit_row(exact, match="exact")
+
+        candidates = self._db.execute(
+            "SELECT * FROM trajectory_index WHERE scope_key=? AND indexed_at >= ? "
+            "ORDER BY indexed_at DESC LIMIT 500",
+            (scope_key, cutoff),
+        ).fetchall()
+        best = None
+        best_dist = simhash_threshold + 1
+        for row in candidates:
+            dist = hamming(query_fp, simhash_from_sqlite(int(row["input_simhash"])))
+            if dist <= simhash_threshold and dist < best_dist:
+                best = row
+                best_dist = dist
+        if best is None:
+            return None
+        return self._trajectory_hit_row(best, match="simhash")
+
+    @staticmethod
+    def _trajectory_hit_row(row: sqlite3.Row, *, match: str) -> dict[str, Any]:
+        return {
+            "source_run_id": row["source_run_id"],
+            "step_count": int(row["step_count"]),
+            "cost_micros": int(row["cost_micros"]),
+            "tool_sequence": row["tool_sequence"],
+            "step_summary": row["step_summary"],
+            "match": match,
+        }
+
+    def get_trajectory_index_by_run(self, source_run_id: str) -> dict[str, Any] | None:
+        row = self._db.execute(
+            "SELECT * FROM trajectory_index WHERE source_run_id=? ORDER BY indexed_at DESC LIMIT 1",
+            (source_run_id,),
+        ).fetchone()
+        return dict(row) if row else None
 
 
 # ---- row -> model ---------------------------------------------------------- #

--- a/src/tokenops/control/trajectory/__init__.py
+++ b/src/tokenops/control/trajectory/__init__.py
@@ -1,0 +1,15 @@
+"""Trajectory hint cache — scope keys, index build, and lookup helpers."""
+
+__all__ = ["enqueue_completed_run", "schedule_trajectory_drain"]
+
+
+def __getattr__(name: str):
+    if name == "enqueue_completed_run":
+        from tokenops.control.trajectory.enqueue import enqueue_completed_run
+
+        return enqueue_completed_run
+    if name == "schedule_trajectory_drain":
+        from tokenops.control.trajectory.worker import schedule_trajectory_drain
+
+        return schedule_trajectory_drain
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/tokenops/control/trajectory/compress.py
+++ b/src/tokenops/control/trajectory/compress.py
@@ -1,0 +1,43 @@
+"""Compress a run window into a lean trajectory summary for hint injection."""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence
+
+from tokenops.control.core import BoundaryStep
+
+
+def compress_trajectory(steps: Sequence[BoundaryStep]) -> tuple[str, str]:
+    """Return ``(step_summary, tool_sequence)`` from a completed run window."""
+    tool_parts: list[str] = []
+    llm_count = 0
+    last_llm_text = ""
+
+    for step in steps:
+        if step.node_type == "tool":
+            args = step.input.get("args", {}) if isinstance(step.input, dict) else {}
+            arg_str = json.dumps(args, sort_keys=True, default=str)
+            if len(arg_str) > 80:
+                arg_str = arg_str[:77] + "..."
+            tool_parts.append(f"{step.boundary_id}({arg_str})")
+        elif step.node_type == "llm":
+            llm_count += 1
+            if isinstance(step.output, dict):
+                text = step.output.get("text", "")
+                if text:
+                    last_llm_text = str(text)
+
+    tool_sequence = " → ".join(tool_parts) if tool_parts else "(no tool steps)"
+
+    summary_lines = [
+        f"Tool sequence ({len(tool_parts)} calls): {tool_sequence}.",
+        f"LLM steps: {llm_count}.",
+    ]
+    if last_llm_text:
+        preview = last_llm_text.replace("\n", " ")
+        if len(preview) > 200:
+            preview = preview[:197] + "..."
+        summary_lines.append(f"Final output shape: {preview}")
+
+    return "\n".join(summary_lines), tool_sequence

--- a/src/tokenops/control/trajectory/enqueue.py
+++ b/src/tokenops/control/trajectory/enqueue.py
@@ -1,0 +1,64 @@
+"""Run-close enqueue for trajectory index background build."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from tokenops.control.core import BoundaryStep
+from tokenops.control.models import RunRecord, RunRegistration
+from tokenops.control.trajectory.gates import structural_index_eligible
+from tokenops.control.trajectory.scope import input_hash, input_simhash, normalize_input, scope_key, simhash_as_sqlite
+from tokenops.control.trajectory.serialize import window_to_json
+
+if TYPE_CHECKING:
+    from tokenops.control.store import Store
+
+
+def _scope_has_none(registration: RunRegistration, scope_dims: Sequence[str], agent: str) -> bool:
+    key = scope_key(registration, agent, scope_dims)
+    return "_none" in key
+
+
+def enqueue_completed_run(
+    store: "Store",
+    *,
+    rec: RunRecord,
+    registration: RunRegistration,
+    agent: str,
+    window: Sequence[BoundaryStep],
+    policy_params: Mapping[str, Any] | None,
+) -> bool:
+    """Persist a window snapshot and enqueue a background index build. Returns True if enqueued."""
+    params = dict(policy_params or {})
+    if not params.get("enabled", False):
+        return False
+
+    scope_dims = params.get("scope_dims") or ["intent", "agent"]
+    min_steps = int(params.get("min_steps", 2))
+    min_input_chars = int(params.get("min_input_chars", 10))
+
+    if not structural_index_eligible(
+        rec,
+        min_steps=min_steps,
+        min_input_chars=min_input_chars,
+        require_scope=bool(params.get("require_scope", False)),
+        scope_has_none=_scope_has_none(registration, scope_dims, agent),
+    ):
+        return False
+
+    task = rec.task or ""
+    norm = normalize_input(task)
+    sk = scope_key(registration, agent, scope_dims)
+
+    store.save_trajectory_snapshot(rec.run_id, window_to_json(window))
+    store.enqueue_trajectory_build(
+        run_id=rec.run_id,
+        scope_key=sk,
+        input_hash=input_hash(task),
+        input_simhash=simhash_as_sqlite(input_simhash(task)),
+        input_preview=norm[:120],
+        task_text=task,
+        cost_micros=rec.cost_micros,
+        step_count=rec.steps,
+    )
+    return True

--- a/src/tokenops/control/trajectory/gates.py
+++ b/src/tokenops/control/trajectory/gates.py
@@ -1,0 +1,35 @@
+"""Structural eligibility gates for trajectory index writes.
+
+Phase 1: completed / min-steps / min-input only. Quality or constraint-adherence scoring
+is Phase 2 — see docs/policies/trajectory_hint.md.
+"""
+
+from __future__ import annotations
+
+from tokenops.control.models import RunRecord
+from tokenops.control.trajectory.scope import normalize_input
+
+
+def structural_index_eligible(
+    rec: RunRecord,
+    *,
+    min_steps: int = 2,
+    min_input_chars: int = 10,
+    require_scope: bool = False,
+    scope_has_none: bool = False,
+) -> bool:
+    """True when a completed run may be enqueued for background indexing."""
+    if rec.status != "completed":
+        return False
+    if rec.halt_reason:
+        return False
+    if rec.steps < min_steps:
+        return False
+    if rec.cost_micros <= 0:
+        return False
+    task = normalize_input(rec.task or "")
+    if not task or len(task) < min_input_chars:
+        return False
+    if require_scope and scope_has_none:
+        return False
+    return True

--- a/src/tokenops/control/trajectory/hint.py
+++ b/src/tokenops/control/trajectory/hint.py
@@ -1,0 +1,75 @@
+"""Format trajectory index rows into an INJECT hint message."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+HintTier = Literal["sequence_only", "sequence_plus_pitfalls", "full"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TrajectoryHit:
+    source_run_id: str
+    step_count: int
+    cost_micros: int
+    tool_sequence: str
+    step_summary: str
+    match: str  # "exact" | "simhash"
+
+
+def hint_tier_for(
+    index_step_count: int,
+    *,
+    sequence_only_max_steps: int = 6,
+    sequence_plus_pitfalls_max_steps: int = 12,
+) -> HintTier:
+    """Pick hint depth from indexed trajectory length — longer paths get richer hints."""
+    if index_step_count <= sequence_only_max_steps:
+        return "sequence_only"
+    if index_step_count <= sequence_plus_pitfalls_max_steps:
+        return "sequence_plus_pitfalls"
+    return "full"
+
+
+def format_hint(
+    entry: TrajectoryHit,
+    *,
+    tier: HintTier | None = None,
+    max_chars: int = 1600,
+    sequence_only_max_steps: int = 6,
+    sequence_plus_pitfalls_max_steps: int = 12,
+) -> str:
+    tier = tier or hint_tier_for(
+        entry.step_count,
+        sequence_only_max_steps=sequence_only_max_steps,
+        sequence_plus_pitfalls_max_steps=sequence_plus_pitfalls_max_steps,
+    )
+    cost_usd = entry.cost_micros / 1_000_000
+    header = (
+        "[TokenOps trajectory hint — guidance only; verify current state.]\n\n"
+        f"Similar completed run ({entry.source_run_id}, {entry.step_count} steps, "
+        f"${cost_usd:.2f}, {entry.match} match):\n"
+    )
+    footer = "\nUse as a starting playbook, not a final answer."
+
+    if tier == "sequence_only":
+        body = f"{header}  Path: {entry.tool_sequence}{footer}"
+    elif tier == "sequence_plus_pitfalls":
+        body = (
+            f"{header}  Path: {entry.tool_sequence}\n"
+            "  Avoid repeating identical tool args without new information; "
+            "follow the sequence order when possible."
+            f"{footer}"
+        )
+    else:
+        body = (
+            f"{header}  Path: {entry.tool_sequence}\n"
+            f"  {entry.step_summary}\n\n"
+            "Use as a starting playbook, not a final answer. Avoid repeating identical tool "
+            "args without new information."
+        )
+
+    if len(body) <= max_chars:
+        return body
+    return body[: max_chars - 3] + "..."

--- a/src/tokenops/control/trajectory/scope.py
+++ b/src/tokenops/control/trajectory/scope.py
@@ -1,0 +1,69 @@
+"""Scope keys and input normalization for trajectory hint lookup."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Mapping, Sequence
+
+from tokenops.control.models import RunRegistration
+from tokenops.control.policies._util import simhash64
+
+_WS = re.compile(r"\s+")
+
+
+def simhash_as_sqlite(v: int) -> int:
+    """Store SimHash as signed 64-bit for SQLite INTEGER."""
+    v &= (1 << 64) - 1
+    if v >= (1 << 63):
+        return v - (1 << 64)
+    return v
+
+
+def simhash_from_sqlite(v: int) -> int:
+    if v < 0:
+        return v + (1 << 64)
+    return v
+
+
+def normalize_input(text: str) -> str:
+    """Deterministic normalization for cache keys — no tokenizer, no model."""
+    return _WS.sub(" ", text.strip().lower())
+
+
+def input_hash(text: str) -> str:
+    return hashlib.sha256(normalize_input(text).encode()).hexdigest()
+
+
+def input_simhash(text: str) -> int:
+    return simhash64(normalize_input(text))
+
+
+def scope_key(
+    registration: RunRegistration,
+    agent: str,
+    scope_dims: Sequence[str],
+) -> str:
+    """Build a stable partition key from registration + agent."""
+    parts: list[str] = []
+    for dim in sorted(scope_dims):
+        if dim == "intent":
+            val = registration.intent or "_none"
+        elif dim == "agent":
+            val = agent or "_none"
+        else:
+            val = registration.user_dims.get(dim, "_none")
+        parts.append(f"{dim}={val}")
+    return "|".join(parts)
+
+
+def scope_from_tags(
+    *,
+    intent: str,
+    agent: str,
+    tags: Mapping[str, str],
+    scope_dims: Sequence[str],
+) -> str:
+    """Scope key when only Attribution tags are available (intent lives in tags)."""
+    reg = RunRegistration(run_id="", intent=intent, user_dims=dict(tags))
+    return scope_key(reg, agent, scope_dims)

--- a/src/tokenops/control/trajectory/serialize.py
+++ b/src/tokenops/control/trajectory/serialize.py
@@ -1,0 +1,66 @@
+"""Serialize BoundaryStep windows for durable snapshot storage."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence
+
+from tokenops.control.core import BoundaryStep, Usage
+
+
+def _usage_to_dict(u: Usage | None) -> dict[str, int] | None:
+    if u is None:
+        return None
+    return {"input": u.input, "output": u.output, "cached": u.cached, "reasoning": u.reasoning}
+
+
+def _usage_from_dict(d: dict[str, int] | None) -> Usage | None:
+    if not d:
+        return None
+    return Usage(
+        input=d.get("input", 0),
+        output=d.get("output", 0),
+        cached=d.get("cached", 0),
+        reasoning=d.get("reasoning", 0),
+    )
+
+
+def step_to_dict(step: BoundaryStep) -> dict[str, Any]:
+    return {
+        "step": step.step,
+        "ts": step.ts,
+        "node_type": step.node_type,
+        "boundary_id": step.boundary_id,
+        "cum_spent_micros": step.cum_spent_micros,
+        "input": dict(step.input),
+        "output": dict(step.output),
+        "tags": dict(step.tags),
+        "usage": _usage_to_dict(step.usage),
+        "signature": step.signature,
+        "result_hash": step.result_hash,
+    }
+
+
+def step_from_dict(d: dict[str, Any]) -> BoundaryStep:
+    return BoundaryStep(
+        step=d["step"],
+        ts=d["ts"],
+        node_type=d["node_type"],
+        boundary_id=d["boundary_id"],
+        cum_spent_micros=d["cum_spent_micros"],
+        input=d.get("input") or {},
+        output=d.get("output") or {},
+        tags=d.get("tags") or {},
+        usage=_usage_from_dict(d.get("usage")),
+        signature=d.get("signature"),
+        result_hash=d.get("result_hash"),
+    )
+
+
+def window_to_json(steps: Sequence[BoundaryStep]) -> str:
+    return json.dumps([step_to_dict(s) for s in steps], separators=(",", ":"))
+
+
+def window_from_json(raw: str) -> list[BoundaryStep]:
+    data = json.loads(raw)
+    return [step_from_dict(d) for d in data]

--- a/src/tokenops/control/trajectory/worker.py
+++ b/src/tokenops/control/trajectory/worker.py
@@ -1,0 +1,29 @@
+"""In-process background drain for trajectory index build queue."""
+
+from __future__ import annotations
+
+import threading
+
+from tokenops.control.store import Store
+
+_drain_lock = threading.Lock()
+
+
+def schedule_trajectory_drain(
+    store: Store,
+    *,
+    limit: int = 8,
+    max_age_days: int = 30,
+    max_entries_per_scope: int = 500,
+) -> None:
+    """Fire-and-forget drain of the trajectory build queue in a daemon thread."""
+
+    def _run() -> None:
+        with _drain_lock:
+            store.drain_trajectory_build_queue(
+                limit=limit,
+                max_age_days=max_age_days,
+                max_entries_per_scope=max_entries_per_scope,
+            )
+
+    threading.Thread(target=_run, daemon=True, name="trajectory-index-drain").start()

--- a/tests/test_trajectory_hint.py
+++ b/tests/test_trajectory_hint.py
@@ -1,0 +1,244 @@
+"""trajectory_hint policy — lookup, inject, and background index build."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tokenops.control import ActionKind, CallRequest, build_governor
+from tokenops.control.core import BoundaryStep
+from tokenops.control.models import RunRecord, RunRegistration
+from tokenops.control.policies.trajectory_hint import build as build_trajectory_hint
+from tokenops.control.trajectory.enqueue import enqueue_completed_run
+from tokenops.control.trajectory.scope import input_hash, input_simhash, normalize_input, scope_key
+from conftest import CollectingControls, FakeView, make_attr, toy_price
+
+HINT_CFG = {
+    "governance": {
+        "budgets": [{"id": "run_llm_cap", "limit_micros": 1_000_000, "dimension": "run"}],
+        "policies": {
+            "trajectory_hint": {
+                "enabled": True,
+                "scope_dims": ["intent", "agent"],
+                "max_age_days": 30,
+                "max_entries_per_scope": 100,
+                "simhash_threshold": 4,
+                "min_steps": 2,
+                "min_index_steps": 4,
+                "sequence_only_max_steps": 6,
+                "sequence_plus_pitfalls_max_steps": 12,
+                "min_input_chars": 10,
+            },
+        },
+    }
+}
+
+
+@pytest.fixture
+def store(tmp_path):
+    from tokenops.control.store import Store
+
+    s = Store(str(tmp_path / "t.db"))
+    yield s
+    s.close()
+
+
+def _tool_step(step: int = 1) -> BoundaryStep:
+    return BoundaryStep(
+        step=step, ts=float(step), node_type="tool", boundary_id="search",
+        cum_spent_micros=500,
+        input={"name": "search", "args": {"query": "pricing"}},
+        output={"snippet": "ok"},
+        signature="sig1", result_hash="rh1",
+    )
+
+
+def test_scope_key_from_registration():
+    reg = RunRegistration(run_id="r1", intent="research", user_dims={"team": "growth"})
+    assert scope_key(reg, "research", ["intent", "agent"]) == "agent=research|intent=research"
+    assert "team=growth" in scope_key(reg, "research", ["intent", "agent", "team"])
+
+
+def test_enqueue_skipped_when_disabled(store):
+    reg = RunRegistration(run_id="r1", intent="demo")
+    rec = RunRecord(
+        run_id="r1", agent="research", status="completed", task="find pricing API docs",
+        cost_micros=1000, steps=5,
+    )
+    assert not enqueue_completed_run(
+        store, rec=rec, registration=reg, agent="research", window=[_tool_step()],
+        policy_params={"enabled": False},
+    )
+    assert store._db.execute("SELECT COUNT(*) FROM trajectory_build_queue").fetchone()[0] == 0
+
+
+def test_enqueue_and_drain_builds_index(store):
+    reg = RunRegistration(run_id="run-a", intent="demo")
+    task = "find pricing API documentation"
+    rec = RunRecord(
+        run_id="run-a", agent="research", status="completed", task=task,
+        cost_micros=50_000, steps=4,
+    )
+    params = HINT_CFG["governance"]["policies"]["trajectory_hint"]
+    assert enqueue_completed_run(
+        store, rec=rec, registration=reg, agent="research",
+        window=[_tool_step(), _tool_step(2)], policy_params=params,
+    )
+    assert store.drain_trajectory_build_queue(max_age_days=30) == 1
+
+    sk = scope_key(reg, "research", ["intent", "agent"])
+    hit = store.lookup_trajectory_index(
+        scope_key=sk,
+        input_hash=input_hash(task),
+        input_simhash=0,
+        max_age_days=30,
+        simhash_threshold=4,
+    )
+    assert hit is not None
+    assert hit["source_run_id"] == "run-a"
+    assert "search" in hit["tool_sequence"]
+
+
+def test_simhash_lookup_paraphrase(store):
+    reg = RunRegistration(run_id="run-a", intent="demo")
+    task = "research enterprise saas pricing models and subscription tiers"
+    paraphrase = "enterprise research saas pricing models and subscription tiers"
+    assert input_hash(task) != input_hash(paraphrase)
+
+    rec = RunRecord(
+        run_id="run-a", agent="research", status="completed", task=task,
+        cost_micros=50_000, steps=3,
+    )
+    params = HINT_CFG["governance"]["policies"]["trajectory_hint"]
+    enqueue_completed_run(
+        store, rec=rec, registration=reg, agent="research",
+        window=[_tool_step()], policy_params=params,
+    )
+    store.drain_trajectory_build_queue(max_age_days=30)
+
+    sk = scope_key(reg, "research", ["intent", "agent"])
+    from tokenops.control.trajectory.scope import input_simhash as ish, simhash_as_sqlite
+
+    hit = store.lookup_trajectory_index(
+        scope_key=sk,
+        input_hash=input_hash(paraphrase),
+        input_simhash=simhash_as_sqlite(ish(paraphrase)),
+        max_age_days=30,
+        simhash_threshold=4,
+    )
+    assert hit is not None
+    assert hit["match"] == "simhash"
+
+
+def test_pre_call_injects_on_step_zero(store):
+    reg = RunRegistration(run_id="prior", intent="demo")
+    task = "find enterprise pricing limits"
+    rec = RunRecord(
+        run_id="prior", agent="research", status="completed", task=task,
+        cost_micros=40_000, steps=5,
+    )
+    params = HINT_CFG["governance"]["policies"]["trajectory_hint"]
+    enqueue_completed_run(
+        store, rec=rec, registration=reg, agent="research",
+        window=[_tool_step()], policy_params=params,
+    )
+    store.drain_trajectory_build_queue(max_age_days=30)
+
+    controls = CollectingControls()
+    gov = build_governor(HINT_CFG, toy_price, controls, store=store)
+    gov.ledger.open_run("run-new")
+    store.create_run(
+        RunRecord(run_id="run-new", agent="research", status="running", task=task,
+                  started_at=time.time()),
+    )
+
+    attr = make_attr(run_id="run-new", agent="research", tags={"intent": "demo"})
+    gov.pre_call(CallRequest(
+        attr=attr, provider="openai", model="gpt-4o-mini", primary_agent_turn=True,
+    ))
+    injects = controls.of_kind(ActionKind.INJECT)
+    assert len(injects) == 1
+    assert "trajectory hint" in (injects[0].inject_message or "").lower()
+
+    # edge-trigger: second pre_call on step 0 state should not double-inject
+    gov.pre_call(CallRequest(attr=attr, provider="openai", model="gpt-4o-mini"))
+    assert len(controls.of_kind(ActionKind.INJECT)) == 1
+
+
+def test_no_inject_when_step_count_nonzero(store):
+    controls = CollectingControls()
+    gov = build_governor(HINT_CFG, toy_price, controls, store=store)
+    gov.ledger.open_run("run-new")
+    store.create_run(
+        RunRecord(run_id="run-new", agent="research", status="running",
+                  task="find enterprise pricing limits", started_at=time.time()),
+    )
+    attr = make_attr(run_id="run-new", agent="research", tags={"intent": "demo"})
+    view = FakeView(_steps=2)
+    det, _ = build_trajectory_hint(store, enabled=True, max_age_days=30)
+    assert det.pre_call(
+        CallRequest(attr=attr, provider="openai", model="gpt-4o-mini"), view,
+    ) is None
+
+
+def test_trajectory_hint_requires_store():
+    with pytest.raises(ValueError, match="requires store"):
+        build_governor(HINT_CFG, toy_price)
+
+
+def test_skip_inject_when_index_steps_below_min_index_steps(store):
+    reg = RunRegistration(run_id="prior", intent="demo")
+    task = "find enterprise pricing limits today"
+    rec = RunRecord(
+        run_id="prior", agent="research", status="completed", task=task,
+        cost_micros=40_000, steps=2,
+    )
+    params = {**HINT_CFG["governance"]["policies"]["trajectory_hint"], "min_index_steps": 4}
+    enqueue_completed_run(
+        store, rec=rec, registration=reg, agent="research",
+        window=[_tool_step()], policy_params=params,
+    )
+    store.drain_trajectory_build_queue(max_age_days=30)
+
+    controls = CollectingControls()
+    cfg = {
+        "governance": {
+            "budgets": HINT_CFG["governance"]["budgets"],
+            "policies": {"trajectory_hint": params},
+        }
+    }
+    gov = build_governor(cfg, toy_price, controls, store=store)
+    gov.ledger.open_run("run-new")
+    store.create_run(
+        RunRecord(run_id="run-new", agent="research", status="running", task=task,
+                  started_at=time.time()),
+    )
+    attr = make_attr(run_id="run-new", agent="research", tags={"intent": "demo"})
+    gov.pre_call(CallRequest(attr=attr, provider="openai", model="gpt-4o-mini", primary_agent_turn=True))
+    assert controls.of_kind(ActionKind.INJECT) == []
+
+
+def test_tiered_hint_format():
+    from tokenops.control.trajectory.hint import TrajectoryHit, format_hint, hint_tier_for
+
+    hit = TrajectoryHit(
+        source_run_id="run-x",
+        step_count=5,
+        cost_micros=100_000,
+        tool_sequence="search → paginate",
+        step_summary="Tool sequence (2 calls): search → paginate.\nLLM steps: 3.",
+        match="exact",
+    )
+    assert hint_tier_for(5) == "sequence_only"
+    short = format_hint(hit, tier="sequence_only")
+    assert "search → paginate" in short
+    assert "LLM steps" not in short
+
+    hit_long = TrajectoryHit(
+        source_run_id="run-y", step_count=14, cost_micros=200_000,
+        tool_sequence="a → b", step_summary="Full summary line.", match="simhash",
+    )
+    assert hint_tier_for(14) == "full"
+    full = format_hint(hit_long, tier="full")
+    assert "Full summary line" in full

--- a/tests/test_trajectory_hint_e2e.py
+++ b/tests/test_trajectory_hint_e2e.py
@@ -1,0 +1,208 @@
+"""E2E: prior run indexed → second run gets trajectory hint on first LLM dispatch."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tokenops.control import ApplyControls, build_governor, build_attribution, wrap_complete
+from tokenops.control.core import BoundaryStep, Observation, Usage
+from tokenops.control.models import PolicyInstance, RunRecord, RunRegistration
+from tokenops.control.trajectory.enqueue import enqueue_completed_run
+from tokenops.control.trajectory.scope import input_hash
+from conftest import make_attr, toy_price
+
+
+HINT_GOVERNANCE = {
+    "governance": {
+        "budgets": [{"id": "run_llm_cap", "limit_micros": 5_000_000, "dimension": "run"}],
+        "policies": {
+            "trajectory_hint": {
+                "enabled": True,
+                "scope_dims": ["intent", "agent"],
+                "max_age_days": 30,
+                "max_entries_per_scope": 100,
+                "simhash_threshold": 4,
+                "min_steps": 2,
+                "min_input_chars": 10,
+            },
+        },
+    }
+}
+
+TASK = "research enterprise saas pricing models and subscription tiers"
+PARAPHRASE = "enterprise research saas pricing models and subscription tiers"
+
+
+def _fake_dispatch(calls: list):
+    def dispatch(provider, model, messages, max_output_tokens=None):
+        calls.append({"model": model, "messages": list(messages), "max_output_tokens": max_output_tokens})
+        from tokenops.providers.types import ModelResponse
+
+        return ModelResponse(content="ok", input_tokens=10, output_tokens=5)
+
+    return dispatch
+
+
+def _tool_step(step: int = 1) -> BoundaryStep:
+    return BoundaryStep(
+        step=step, ts=float(step), node_type="tool", boundary_id="search",
+        cum_spent_micros=12_000,
+        input={"name": "search", "args": {"query": "pricing"}},
+        output={"snippet": "tier list"},
+        signature="sig1", result_hash="rh1",
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    from tokenops.control.store import Store
+
+    s = Store(str(tmp_path / "hint_e2e.db"))
+    s.upsert_policy_instance(
+        PolicyInstance(
+            id="pi_traj",
+            template="trajectory_hint",
+            params=HINT_GOVERNANCE["governance"]["policies"]["trajectory_hint"],
+            agent="research",
+        )
+    )
+    yield s
+    s.close()
+
+
+def test_trajectory_hint_end_to_end_via_wrap_complete(store):
+    """Run A completes and is indexed; Run B's first governed LLM call receives the hint."""
+    # ---- Run A: complete, index (sync drain — no daemon thread in tests) ----
+    reg_a = store.register_run(
+        RunRegistration(run_id="run-a", intent="pricing_research", user_dims={"user_id": "alice"}),
+    )
+    rec_a = RunRecord(
+        run_id="run-a", agent="research", status="completed", task=TASK,
+        cost_micros=120_000, steps=4, started_at=time.time(), ended_at=time.time(),
+    )
+    store.create_run(rec_a)
+    window_a = [_tool_step(1), _tool_step(2)]
+    assert enqueue_completed_run(
+        store,
+        rec=rec_a,
+        registration=reg_a,
+        agent="research",
+        window=window_a,
+        policy_params=HINT_GOVERNANCE["governance"]["policies"]["trajectory_hint"],
+    )
+    assert store.drain_trajectory_build_queue(max_age_days=30) == 1
+
+    # ---- Run B: cold start, same intent/agent, paraphrased task ----
+    reg_b = store.register_run(
+        RunRegistration(run_id="run-b", intent="pricing_research", user_dims={"user_id": "bob"}),
+    )
+    attr_b = build_attribution(reg_b, service="research")
+    store.create_run(
+        RunRecord(
+            run_id="run-b", agent="research", status="running", task=PARAPHRASE,
+            started_at=time.time(),
+        ),
+    )
+
+    assert input_hash(TASK) != input_hash(PARAPHRASE)
+
+    gov = build_governor(HINT_GOVERNANCE, toy_price, ApplyControls(), store=store)
+    gov.ledger.open_run("run-b")
+
+    calls: list = []
+    governed = wrap_complete(
+        gov, gov.controls, attr_b,
+        provider="openai", model="gpt-4o-mini",
+        dispatch=_fake_dispatch(calls), service="research",
+    )
+
+    governed("openai", "gpt-4o-mini", [{"role": "user", "content": PARAPHRASE}])
+
+    assert len(calls) == 1
+    messages = calls[0]["messages"]
+    assert messages[0] == {"role": "user", "content": PARAPHRASE}
+    hint_turn = messages[-1]
+    assert hint_turn["role"] == "user"
+    assert "trajectory hint" in hint_turn["content"].lower()
+    assert "run-a" in hint_turn["content"]
+    assert "search" in hint_turn["content"]
+    assert gov.controls.carry == []  # consumed by wrap
+
+
+def test_trajectory_hint_no_hint_on_cold_start(store):
+    """First-ever run for a task gets no hint injected."""
+    reg = store.register_run(
+        RunRegistration(run_id="run-cold", intent="pricing_research", user_dims={"user_id": "carol"}),
+    )
+    attr = build_attribution(reg, service="research")
+    store.create_run(
+        RunRecord(
+            run_id="run-cold", agent="research", status="running",
+            task="brand new unique task about widget inventory",
+            started_at=time.time(),
+        ),
+    )
+
+    gov = build_governor(HINT_GOVERNANCE, toy_price, ApplyControls(), store=store)
+    gov.ledger.open_run("run-cold")
+
+    calls: list = []
+    governed = wrap_complete(
+        gov, gov.controls, attr,
+        provider="openai", model="gpt-4o-mini",
+        dispatch=_fake_dispatch(calls), service="research",
+    )
+    governed("openai", "gpt-4o-mini", [{"role": "user", "content": "brand new unique task about widget inventory"}])
+
+    assert len(calls) == 1
+    assert len(calls[0]["messages"]) == 1  # no hint turn appended
+
+
+def test_trajectory_hint_not_reinjected_on_second_llm_call(store):
+    """Hint fires once at step 0; the second LLM call in the same run has no hint."""
+    reg_a = store.register_run(
+        RunRegistration(run_id="run-a2", intent="pricing_research", user_dims={"user_id": "alice"}),
+    )
+    rec_a = RunRecord(
+        run_id="run-a2", agent="research", status="completed", task=TASK,
+        cost_micros=120_000, steps=4, started_at=time.time(), ended_at=time.time(),
+    )
+    store.create_run(rec_a)
+    enqueue_completed_run(
+        store, rec=rec_a, registration=reg_a, agent="research",
+        window=[_tool_step()], policy_params=HINT_GOVERNANCE["governance"]["policies"]["trajectory_hint"],
+    )
+    store.drain_trajectory_build_queue(max_age_days=30)
+
+    reg_b = store.register_run(
+        RunRegistration(run_id="run-b2", intent="pricing_research", user_dims={"user_id": "bob"}),
+    )
+    attr_b = build_attribution(reg_b, service="research")
+    store.create_run(
+        RunRecord(run_id="run-b2", agent="research", status="running", task=TASK, started_at=time.time()),
+    )
+
+    gov = build_governor(HINT_GOVERNANCE, toy_price, ApplyControls(), store=store)
+    gov.ledger.open_run("run-b2")
+
+    calls: list = []
+    governed = wrap_complete(
+        gov, gov.controls, attr_b,
+        provider="openai", model="gpt-4o-mini",
+        dispatch=_fake_dispatch(calls), service="research",
+    )
+
+    governed("openai", "gpt-4o-mini", [{"role": "user", "content": TASK}])
+    assert len(calls[0]["messages"]) == 2  # task + hint
+
+    # Record one LLM step so step_count > 0 for the next call.
+    gov.observe(Observation(
+        attr=attr_b, node_type="llm", boundary_id="research.chat", ts=time.time(),
+        provider="openai", model="gpt-4o-mini", usage=Usage(input=10, output=5),
+        output={"text": "ok"},
+    ))
+
+    governed("openai", "gpt-4o-mini", [{"role": "user", "content": "follow up"}])
+    assert len(calls[1]["messages"]) == 1  # no second hint


### PR DESCRIPTION
## Summary
- Add `trajectory_hint` policy: background SQLite index of completed runs, SimHash/exact lookup, and one-shot INJECT on the first primary-agent LLM turn.
- Gate injection with `min_index_steps` and tiered hint payloads (`sequence_only` → `full`); policy stays **disabled by default** (opt-in via `steering_trajectory` bench preset).
- Wire browser-use integration, live bench script (`run_trajectory_hint_bench.py` with `--pause-seconds`), unit/e2e tests, and policy docs including Phase 1 bench learnings.
- Also includes live benchmark process documentation from the branch base commit.

## Test plan
- [x] `pytest tests/test_trajectory_hint.py tests/test_trajectory_hint_e2e.py` (12 passed)
- [x] Live bench `example_tight_cap`: hints skipped for 2-step index, ~0% cost delta
- [x] Live bench `books_pagination_stress` with `--pause-seconds 120`: hints fire on long trajectories, no TPM 429s


Made with [Cursor](https://cursor.com)