### PR TITLE
Fix triad.yaml: tool_reject → tool_fix

### DIFF
--- a/src/tokenops/config/triad.yaml
+++ b/src/tokenops/config/triad.yaml
@@ -56,7 +56,7 @@ governance:
     concurrency_cap:
       max_concurrent: 4
       mode: reject
-    tool_reject:
+    tool_fix:
       registry: [search, fetch]
       k: 4
     tool_output_cap:


### PR DESCRIPTION
## Summary
- Renames invalid governance policy key `tool_reject` to `tool_fix` in `src/tokenops/config/triad.yaml`.
- Matches the registered policy in `build_governor` / `control/policies` so `make db-reset` no longer fails on unknown policy.

## Test plan
- [ ] `make db-reset` completes without governance config errors
- [ ] Confirm `src/tokenops/control/config.py` still maps `tool_fix` (not `tool_reject`)
- [ ] Spot-check triad bench seed loads governance policies as expected


Made with [Cursor](https://cursor.com)