### PR TITLE
Chronicle-shaped README and agent-tokenops PyPI release

### DIFF
--- a/.cursor/skills/interactive-readme/references/assets-and-badges.md
+++ b/.cursor/skills/interactive-readme/references/assets-and-badges.md
@@ -90,7 +90,7 @@ Set FontSize 18
 Set Width 1200
 Set Height 700
 Set Theme "Catppuccin Mocha"
-Type "pip install tokenops"
+Type "pip install agent-tokenops"
 Enter
 Sleep 1s
 Type "# show the core loop"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,64 @@
 name: Release
 
-# Publishing a GitHub Release triggers a build and upload to PyPI.
-# See RELEASING.md for the one-time PyPI Trusted Publisher setup.
+# One-shot release: optional tag input → verify → build → tag → GitHub Release → PyPI.
+# See RELEASING.md for Trusted Publisher setup.
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.0). Leave empty to use v{version} from pyproject.toml."
+        required: false
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create tag + GitHub Release
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Verify tag matches package version
-        # Guard against cutting a release before the version bump is merged:
-        # the tag (vX.Y.Z) must match pyproject's version, or we would publish
-        # the wrong version under the tag's name.
+      - name: Resolve tag and verify against pyproject
+        id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
           version="$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
-          echo "release tag: $tag | pyproject version: $version"
-          if [ "$tag" != "$version" ]; then
-            echo "::error::Release tag v$tag does not match pyproject version $version. Bump the version and merge it before creating the release."
+          if [ -n "${INPUT_TAG}" ]; then
+            tag="${INPUT_TAG}"
+          else
+            tag="v${version}"
+          fi
+          # Accept either "0.1.0" or "v0.1.0"
+          case "$tag" in
+            v*) ;;
+            *) tag="v${tag}" ;;
+          esac
+          tag_version="${tag#v}"
+          echo "tag: $tag | pyproject version: $version | sha: $GITHUB_SHA"
+          if [ "$tag_version" != "$version" ]; then
+            echo "::error::Tag $tag does not match pyproject version $version. Bump version (and __version__) and merge before releasing."
             exit 1
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Build sdist and wheel
         run: |
@@ -39,17 +70,51 @@ jobs:
           pip install "twine>=6"
           twine check dist/*
 
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            existing="$(git rev-list -n 1 "${TAG}")"
+            if [ "$existing" != "$GITHUB_SHA" ]; then
+              echo "::error::Tag ${TAG} already exists on $existing, not $GITHUB_SHA."
+              exit 1
+            fi
+            echo "Tag ${TAG} already points at this commit; reusing."
+          else
+            git tag "${TAG}" "$GITHUB_SHA"
+            git push origin "refs/tags/${TAG}"
+          fi
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::error::GitHub Release ${TAG} already exists. Delete it or bump the version."
+            exit 1
+          fi
+
+          gh release create "${TAG}" dist/* \
+            --title "agent-tokenops ${VERSION}" \
+            --generate-notes \
+            --target "$GITHUB_SHA"
+
       - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
 
   publish:
-    needs: build
+    needs: release
     runs-on: ubuntu-latest
-    # Trusted Publishing (OIDC) — no API tokens stored. Matches the `pypi`
-    # environment and `release.yml` workflow name configured on PyPI.
-    environment: pypi
+    # Trusted Publishing (OIDC) — no API tokens. Matches PyPI pending publisher:
+    # workflow release.yml + environment pypi.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/agent-tokenops/
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+# Publishing a GitHub Release triggers a build and upload to PyPI.
+# See RELEASING.md for the one-time PyPI Trusted Publisher setup.
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches package version
+        # Guard against cutting a release before the version bump is merged:
+        # the tag (vX.Y.Z) must match pyproject's version, or we would publish
+        # the wrong version under the tag's name.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "release tag: $tag | pyproject version: $version"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Release tag v$tag does not match pyproject version $version. Bump the version and merge it before creating the release."
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          pip install "build>=1.2"
+          python -m build
+
+      - name: Check metadata
+        run: |
+          pip install "twine>=6"
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC) — no API tokens stored. Matches the `pypi`
+    # environment and `release.yml` workflow name configured on PyPI.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-23
+
+### Added
+
+- Initial PyPI package (`agent-tokenops`): control plane (`python -m tokenops.server`),
+  SDK (`wrap_complete`, ledger/policies, Chronicle crossing hook), and Admin UI.
+- Default governance seed shipped as package data (`tokenops/config/default.yaml`).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tisha Chawla and Susheem Koul
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 	planner-server researcher-server writer-server \
 	scout-server analyst-server editor-server \
 	stop-demo stop-triad stop-brief \
-	db-clear db-reseed db-reset
+	db-clear db-reseed db-reset \
+	dist check-dist
 
 PYTHON ?= python3
 export PYTHONPATH := .$(if $(PYTHONPATH),:$(PYTHONPATH),)
@@ -13,6 +14,16 @@ export TOKENOPS_CONFIG ?= src/tokenops/config/default.yaml
 install:
 	$(PYTHON) -m pip install --upgrade pip setuptools wheel
 	$(PYTHON) -m pip install -e ".[dev,examples]"
+
+# Build sdist + wheel under dist/ (see RELEASING.md).
+dist:
+	rm -rf dist build *.egg-info src/*.egg-info
+	$(PYTHON) -m pip install -q "build>=1.2"
+	$(PYTHON) -m build
+
+check-dist: dist
+	$(PYTHON) -m pip install -q "twine>=6"
+	$(PYTHON) -m twine check dist/*
 
 control-plane:
 	$(PYTHON) -m tokenops.server

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 Cap spend and steer behavior across a whole agent workflow — not per request — with a shared ledger and in-path enforcement.
 
 [![CI](https://github.com/theagentplane/tokenops/actions/workflows/test.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/test.yml)
+[![PyPI](https://img.shields.io/pypi/v/agent-tokenops.svg)](https://pypi.org/project/agent-tokenops/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://github.com/theagentplane/tokenops)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 [![Status](https://img.shields.io/badge/status-0.x%20%7C%20draft-7B61FF?style=flat-square)](https://semver.org/)
 [![Stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=flat&color=yellow)](https://github.com/theagentplane/tokenops/stargazers)
 
 <br>
 
-<img src="examples/demo-assets/videos/02_governance_on_budget_cap.png" alt="TokenOps Dashboard: governance halt when worst-case cost exceeds remaining run budget" width="720" />
+<img src="https://raw.githubusercontent.com/theagentplane/tokenops/main/examples/demo-assets/videos/02_governance_on_budget_cap.png" alt="TokenOps Dashboard: governance halt when worst-case cost exceeds remaining run budget" width="720" />
 
 </div>
 
@@ -63,14 +65,17 @@ Chronicle records decision boundaries; TokenOps attaches as the cost/governance 
 ## Install
 
 ```bash
+pip install agent-tokenops
+
+# With example / bench extras (LangChain, ddgs):
+pip install "agent-tokenops[examples]"
+
 # From source (development):
 pip install -e ".[dev,examples]"
-
-# From GitHub:
-pip install "tokenops @ git+https://github.com/theagentplane/tokenops.git"
 ```
 
-Requires Python 3.10+. Not on PyPI yet.
+Requires Python 3.10+. PyPI name is `agent-tokenops`; import is still `tokenops`
+(same pattern as Chronicle). See [`RELEASING.md`](RELEASING.md) for releases.
 
 ## Quick start
 
@@ -172,6 +177,7 @@ Longer table with logos: [`docs/product/comparison.md`](docs/product/comparison.
 | Target | Role |
 |--------|------|
 | `make install` | Editable install with dev + examples extras |
+| `make dist` / `check-dist` | Build sdist+wheel / `twine check` |
 | `make control-plane` | Standalone plane (`python -m tokenops.server`) on `:7700` |
 | `make ui` | Admin + Dashboard on `:8501` |
 | `make run` | Plane + Admin/Dashboard |
@@ -217,7 +223,7 @@ TokenOps is early (0.x). Near-term:
 - User/tag segment-scoped budgets (machinery exists; seed is run-only today).
 - Optional fail-closed mode on missing registration or exceeded budget.
 - Remote observe / decide (fatter plane) for multi-host stacks.
-- PyPI publish and a documentation site.
+- Documentation site.
 
 Status of each control-plane job: [`CONTROL_PLANE.md`](CONTROL_PLANE.md). Ideas welcome via GitHub issues.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,8 @@ TokenOps publishes to PyPI as **`agent-tokenops`** (import: `tokenops`) using
 GitHub Actions with **Trusted Publishing (OIDC)** — no API tokens are stored
 anywhere. Same pattern as Chronicle (`agent-chronicle` → `import chronicle`).
 
+One workflow run is atomic: **verify → build → git tag → GitHub Release → PyPI**.
+
 ## One-time setup (Trusted Publishing)
 
 ### 1. Pending publisher on PyPI
@@ -47,15 +49,17 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 1. Move the `CHANGELOG.md` `[Unreleased]` items under a new version heading with
    today's date; start a fresh empty `[Unreleased]`.
 2. Bump `version` in `pyproject.toml` **and** `__version__` in
-   `src/tokenops/__init__.py` following SemVer.
-3. Commit and tag:
-   ```bash
-   git commit -am "Release vX.Y.Z"
-   git tag vX.Y.Z
-   git push && git push --tags
-   ```
-4. Create a **GitHub Release** from the tag. Publishing the release triggers
-   `release.yml`, which builds and uploads to PyPI automatically.
+   `src/tokenops/__init__.py` following SemVer. Commit and merge to `main`.
+3. In GitHub: **Actions → Release → Run workflow**
+   - Branch: `main` (the commit that has the version bump)
+   - Tag (optional): e.g. `v0.1.0` — leave empty to use `v{version}` from
+     `pyproject.toml`
+4. The workflow will, in one run:
+   1. Require the tag to match `pyproject.toml` version
+   2. Build sdist/wheel and `twine check`
+   3. Create and push the git tag
+   4. Create the GitHub Release (attaches dist artifacts)
+   5. Upload to PyPI (may wait on `pypi` environment approval)
 5. Verify:
    ```bash
    pip install agent-tokenops==X.Y.Z
@@ -66,12 +70,10 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 
 PyPI versions are **immutable** and come from metadata inside the built wheel —
 that metadata is read from `pyproject.toml` at build time. The git tag
-(`v0.1.0`) is only a label on GitHub; it does **not** set the package version.
+(`v0.1.0`) is only a label; it does **not** set the package version.
 
-If you tagged `v0.1.1` but forgot to bump `pyproject.toml` (still `0.1.0`), CI
-would try to upload **0.1.0** again while the Release page says 0.1.1. The
-workflow strips the leading `v` from the Release tag and requires it to equal
-`version` in `pyproject.toml` before upload.
+If you passed tag `v0.1.1` but `pyproject.toml` still says `0.1.0`, the workflow
+refuses to continue. Empty tag input defaults to `v` + the pyproject version.
 
 Also keep `tokenops.__version__` in sync so runtime version matches pip.
 
@@ -79,3 +81,5 @@ Also keep `tokenops.__version__` in sync so runtime version matches pip.
 
 - Stay in `0.x` while the control-plane / SDK surface may still change.
 - Install name: `agent-tokenops`. Import name: `tokenops`.
+- Do not create tags or GitHub Releases by hand for normal cuts — use
+  **Run workflow** so tag, Release, and PyPI stay in lockstep.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing
+
+TokenOps publishes to PyPI as **`agent-tokenops`** (import: `tokenops`) using
+GitHub Actions with **Trusted Publishing (OIDC)** — no API tokens are stored
+anywhere. Same pattern as Chronicle (`agent-chronicle` → `import chronicle`).
+
+## One-time setup (Trusted Publishing)
+
+### 1. Pending publisher on PyPI
+
+1. Sign in at [pypi.org](https://pypi.org) (account that will own the project).
+2. Open [Publishing](https://pypi.org/manage/account/publishing/)
+   (*Your account* → *Publishing*).
+3. Under **Add a new pending publisher**, choose **GitHub** and fill in:
+   - PyPI project name: `agent-tokenops`
+   - Owner: `theagentplane`
+   - Repository: `tokenops`
+   - Workflow filename: `release.yml`
+   - Environment name: `pypi`
+4. Save. The project does **not** exist yet; the first successful CI upload
+   creates it and binds that publisher permanently.
+
+Optional: do the same on [TestPyPI](https://test.pypi.org/manage/account/publishing/)
+for a dry run (same project name `agent-tokenops`).
+
+### 2. GitHub Environment
+
+In the `theagentplane/tokenops` repo:
+
+1. **Settings → Environments → New environment**
+2. Name it exactly `pypi` (must match `environment: pypi` in `release.yml` and
+   the PyPI publisher form).
+3. Optional: add required reviewers so a human must approve before upload.
+
+No secrets needed — OIDC uses `permissions: id-token: write` in `release.yml`.
+
+### 3. Optional TestPyPI dry run
+
+```bash
+make dist
+twine upload --repository testpypi dist/*
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ agent-tokenops
+```
+
+## Cutting a release
+
+1. Move the `CHANGELOG.md` `[Unreleased]` items under a new version heading with
+   today's date; start a fresh empty `[Unreleased]`.
+2. Bump `version` in `pyproject.toml` **and** `__version__` in
+   `src/tokenops/__init__.py` following SemVer.
+3. Commit and tag:
+   ```bash
+   git commit -am "Release vX.Y.Z"
+   git tag vX.Y.Z
+   git push && git push --tags
+   ```
+4. Create a **GitHub Release** from the tag. Publishing the release triggers
+   `release.yml`, which builds and uploads to PyPI automatically.
+5. Verify:
+   ```bash
+   pip install agent-tokenops==X.Y.Z
+   python -c "import tokenops; print(tokenops.__version__)"
+   ```
+
+## Version matching (why the workflow checks)
+
+PyPI versions are **immutable** and come from metadata inside the built wheel —
+that metadata is read from `pyproject.toml` at build time. The git tag
+(`v0.1.0`) is only a label on GitHub; it does **not** set the package version.
+
+If you tagged `v0.1.1` but forgot to bump `pyproject.toml` (still `0.1.0`), CI
+would try to upload **0.1.0** again while the Release page says 0.1.1. The
+workflow strips the leading `v` from the Release tag and requires it to equal
+`version` in `pyproject.toml` before upload.
+
+Also keep `tokenops.__version__` in sync so runtime version matches pip.
+
+## Versioning notes
+
+- Stay in `0.x` while the control-plane / SDK surface may still change.
+- Install name: `agent-tokenops`. Import name: `tokenops`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,38 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "tokenops"
+name = "agent-tokenops"
 version = "0.1.0"
 description = "TokenOps control plane and SDK for run-aware agent token governance"
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+license-files = ["LICENSE.txt"]
+authors = [
+  { name = "Susheem Koul" },
+  { name = "Tisha Chawla" },
+]
+keywords = [
+  "llm",
+  "agents",
+  "governance",
+  "token-budget",
+  "multi-agent",
+  "control-plane",
+  "cost-control",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: System :: Systems Administration",
+]
 dependencies = [
   "agent-chronicle>=0.1.1",
   "openai>=1.0",
@@ -21,13 +46,23 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = [
+  "pytest>=8.0",
+  "build>=1.2",
+  "twine>=6.0",
+]
 examples = [
   "ddgs>=9.0",
   "langchain-core>=0.3",
   "langchain-openai>=0.2",
   "langchain-anthropic>=0.2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/theagentplane/tokenops"
+Repository = "https://github.com/theagentplane/tokenops"
+Issues = "https://github.com/theagentplane/tokenops/issues"
+Changelog = "https://github.com/theagentplane/tokenops/blob/main/CHANGELOG.md"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -44,3 +79,7 @@ addopts = "-m 'not e2e and not live'"
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["tokenops*"]
+
+# Ship the default governance YAML with the wheel (loader resolves via Path(__file__)).
+[tool.setuptools.package-data]
+tokenops = ["config/*.yaml"]

--- a/tests/benchmarking/__init__.py
+++ b/tests/benchmarking/__init__.py
@@ -1,1 +1,0 @@
-# Empty package marker for pytest collection under tests/benchmarking.

--- a/tests/examples/__init__.py
+++ b/tests/examples/__init__.py
@@ -1,1 +1,0 @@
-# Empty package marker for pytest collection under tests/examples.


### PR DESCRIPTION
## Summary
- Reshape the README to match Chronicle’s OSS front-page structure (badges, install, demos, comparison).
- Add PyPI packaging as `agent-tokenops` (import stays `tokenops`): MIT license, Trusted Publishing release workflow, changelog, and `make dist` / `check-dist`.

## Test plan
- [ ] `make check-dist` — wheel/sdist build and `twine check` pass; metadata `Name: agent-tokenops`
- [ ] Confirm `tokenops/config/default.yaml` is inside the wheel
- [ ] One-time: configure PyPI pending publisher + GitHub `pypi` environment per `RELEASING.md`
- [ ] (After merge) cut `v0.1.0` GitHub Release and verify `pip install agent-tokenops`


Made with [Cursor](https://cursor.com)