### PR TITLE
Fix README CI badge after test.yml → ci.yml rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Run-aware token governance for multi-agent systems.**<br>
 Cap spend and steer behavior across a whole agent workflow — not per request — with a shared ledger and in-path enforcement.
 
-[![CI](https://github.com/theagentplane/tokenops/actions/workflows/test.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/test.yml)
+[![CI](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-tokenops.svg)](https://pypi.org/project/agent-tokenops/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://github.com/theagentplane/tokenops)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)


### PR DESCRIPTION
## Summary
- Update the README CI badge to `.github/workflows/ci.yml` (the `test.yml` workflow was removed in the OSS cleanup).

## Test plan
- [ ] Badge on the PR/branch README renders a valid Actions status (not “workflow doesn’t exist”)
- [ ] Link opens https://github.com/theagentplane/tokenops/actions/workflows/ci.yml

Made with [Cursor](https://cursor.com)