### PR TITLE
Release 0.1.1 (Chronicle ≥0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-24
+
+### Changed
+
+- Require `agent-chronicle>=0.2.0` (was `>=0.1.3`).
+- Harden integration UX: ambient run scope and Chronicle `wrap_llm` dispatch for
+  `wrap_complete` / streaming paths.
+
+### Added
+
+- Onboarding guide (`docs/guides/onboarding.md`) with prereqs, FAQ, and current limits.
+- Broader `wrap_complete` integration coverage for seeded policies.
+
 ## [0.1.0] - 2026-07-23
 
 ### Added

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -29,7 +29,7 @@ Chronicle records decision boundaries; TokenOps observes them for cost/governanc
 | Need | Notes |
 |------|--------|
 | **Python 3.10+** | Required |
-| **`pip install agent-tokenops`** | Import is still `tokenops`. Pulls Chronicle ≥0.1.3, FastAPI, httpx, provider clients, etc. |
+| **`pip install agent-tokenops`** | Import is still `tokenops`. Pulls Chronicle ≥0.2.0, FastAPI, httpx, provider clients, etc. |
 | **Control plane + shared DB** *(multi-process)* | `TOKENOPS_URL` (e.g. `http://localhost:7700`) and `TOKENOPS_DB` shared by plane + agents. Seed governance once (`make db-reset`). |
 | **Or embedded Store** *(single-process / tests)* | Omit `TOKENOPS_URL` or set `TOKENOPS_EMBEDDED=1`. |
 | **LLM API keys** | Only for real model calls — not required for TokenOps itself or offline tests. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-tokenops"
-version = "0.1.0"
+version = "0.1.1"
 description = "TokenOps control plane and SDK for run-aware agent token governance"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,7 +34,7 @@ classifiers = [
   "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-  "agent-chronicle>=0.1.3",
+  "agent-chronicle>=0.2.0",
   "openai>=1.0",
   "anthropic>=0.40",
   "pyyaml>=6.0",

--- a/src/tokenops/__init__.py
+++ b/src/tokenops/__init__.py
@@ -4,7 +4,7 @@ from tokenops.env import load_env
 
 load_env()
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def init() -> None:

--- a/src/tokenops/server/app.py
+++ b/src/tokenops/server/app.py
@@ -6,6 +6,7 @@ import os
 
 from fastapi import FastAPI
 
+from tokenops import __version__
 from tokenops.control.http import mount_run_registration
 from tokenops.control.store import Store
 
@@ -23,7 +24,7 @@ def create_app(store: Store | None = None) -> FastAPI:
     """
     store = store or Store(os.environ.get("TOKENOPS_DB", "tokenops.db"))
 
-    app = FastAPI(title="TokenOps Control Plane", version="0.1.0")
+    app = FastAPI(title="TokenOps Control Plane", version=__version__)
     app.state.store = store
 
     @app.get("/health")


### PR DESCRIPTION
## Summary
- Bump package to **0.1.1** for PyPI
- Require `agent-chronicle>=0.2.0` (latest on PyPI; was `>=0.1.3`)
- Changelog + onboarding doc pin update; FastAPI app version tracks `__version__`

Verified locally: 183 tests pass against Chronicle 0.2.0.

## Test plan
- [ ] CI green
- [ ] After merge: run **Release** workflow on `main` (empty tag → `v0.1.1`)
- [ ] `pip install agent-tokenops==0.1.1` and confirm Chronicle ≥0.2.0 is pulled


Made with [Cursor](https://cursor.com)