### PR TITLE
Depend on agent-chronicle>=0.3.0 from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-  "agent-chronicle @ git+https://github.com/theagentplane/chronicle.git@feat/boundary-on-enter-precall",
+  "agent-chronicle>=0.3.0",
   "openai>=1.0",
   "anthropic>=0.40",
   "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- Replace the temporary `agent-chronicle` git pin (`feat/boundary-on-enter-precall`) with `agent-chronicle>=0.3.0` now that 0.3.0 is on PyPI.
- Follow-up to #39 (already merged); CHANGELOG already documented the 0.3.0 requirement.

## Test plan
- [x] `make lint` (ruff + mypy)
- [x] Relevant boundary/precall tests (19 passed)
- [ ] CI lint-test matrix green


Made with [Cursor](https://cursor.com)