### PR TITLE
HTTP store when CONTROL_PLANE_URL is set

### DIFF
--- a/src/tokenops/control/client.py
+++ b/src/tokenops/control/client.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from tokenops.control.http import post_run, post_run_sync
+from tokenops.control.http_store import HttpStore
 from tokenops.control.models import (
     GovernanceMode,
     RunAlreadyRegisteredError,
@@ -58,23 +59,27 @@ class ControlPlaneClient:
             raise ValueError("exactly one of url or store is required")
         self._url = url.rstrip("/") if url else None
         self._store = store
-        self._hybrid_store: Store | None = None
+        self._hybrid_store: Any = None
         self._timeout = timeout
 
     @classmethod
     def from_env(cls, *, timeout: float = 30.0) -> ControlPlaneClient:
         """Build a client from ``TOKENOPS_URL`` / ``TOKENOPS_EMBEDDED`` / ``TOKENOPS_DB``.
 
-        * ``TOKENOPS_URL`` set and ``TOKENOPS_EMBEDDED`` not ``1`` → HTTP to the plane.
-        * otherwise → embedded :class:`Store` at ``TOKENOPS_DB`` (default ``tokenops.db``).
-
-        Also installs the Chronicle crossing hook (idempotent; design notes §17).
+        * ``TOKENOPS_URL`` or ``CONTROL_PLANE_URL`` set and ``TOKENOPS_EMBEDDED`` not ``1``
+          → HTTP to the plane (no local SQLite).
+        * otherwise → embedded :class:`Store` at ``TOKENOPS_DB``.
         """
         from tokenops.control.crossing import install_crossing_hook
 
         install_crossing_hook()
         embedded = os.environ.get("TOKENOPS_EMBEDDED", "").strip() == "1"
-        url = (os.environ.get("TOKENOPS_URL") or "").strip()
+        url = (
+            os.environ.get("CONTROL_PLANE_URL")
+            or os.environ.get("TOKENOPS_URL")
+            or os.environ.get("TOKENOPS_CONTROL_PLANE_URL")
+            or ""
+        ).strip()
         if url and not embedded:
             return cls(url=url, timeout=timeout)
         db = os.environ.get("TOKENOPS_DB", "tokenops.db")
@@ -98,19 +103,18 @@ class ControlPlaneClient:
         return self._store
 
     def require_store(self) -> Store:
-        """Backing Store for ledger / config / dashboard rows (escape hatch).
+        """Backing store for ledger / config / dashboard rows.
 
-        Embedded mode returns the in-process Store. Remote registration mode
-        lazily opens shared ``TOKENOPS_DB`` for ledger and config until those
-        plane APIs are HTTP (§4 / later waves).
+        Embedded mode returns the in-process SQLite Store. Remote mode returns
+        :class:`HttpStore` — never a local DB file.
         """
         if self._store is not None:
             return self._store
         if self._hybrid_store is None:
-            db = os.environ.get("TOKENOPS_DB", "tokenops.db")
-            logger.debug("tokenops.client hybrid_store path=%s", db)
-            self._hybrid_store = Store(db)
-        return self._hybrid_store
+            assert self._url is not None
+            key = os.environ.get("CONTROL_PLANE_API_KEY") or os.environ.get("TOKENOPS_API_KEY")
+            self._hybrid_store = HttpStore(self._url, api_key=key, timeout=self._timeout)
+        return cast(Store, self._hybrid_store)
 
     def register_run(
         self,

--- a/src/tokenops/control/http.py
+++ b/src/tokenops/control/http.py
@@ -6,6 +6,7 @@ wrap handlers here so Halt/Throttled map to HTTP responses.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
@@ -107,6 +108,15 @@ def _raise_for_response(response: httpx.Response) -> None:
         ) from exc
 
 
+def _plane_auth_headers() -> dict[str, str]:
+    key = (
+        os.environ.get("CONTROL_PLANE_API_KEY") or os.environ.get("TOKENOPS_API_KEY") or ""
+    ).strip()
+    if not key:
+        return {}
+    return {"Authorization": f"Bearer {key}"}
+
+
 async def post_run(
     url: str,
     payload: dict[str, Any],
@@ -116,7 +126,7 @@ async def post_run(
     """POST ``/v1/runs`` at *url*. Prefer :class:`~tokenops.control.client.ControlPlaneClient`."""
     base = url.rstrip("/")
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.post(f"{base}/v1/runs", json=payload)
+        response = await client.post(f"{base}/v1/runs", json=payload, headers=_plane_auth_headers())
         _raise_for_response(response)
         return response.json()
 
@@ -130,6 +140,6 @@ def post_run_sync(
     """Sync POST ``/v1/runs`` at *url*. Prefer :class:`~tokenops.control.client.ControlPlaneClient`."""
     base = url.rstrip("/")
     with httpx.Client(timeout=timeout) as client:
-        response = client.post(f"{base}/v1/runs", json=payload)
+        response = client.post(f"{base}/v1/runs", json=payload, headers=_plane_auth_headers())
         _raise_for_response(response)
         return response.json()

--- a/src/tokenops/control/http_store.py
+++ b/src/tokenops/control/http_store.py
@@ -1,0 +1,217 @@
+"""HTTP-backed Store used when TOKENOPS_URL / CONTROL_PLANE_URL is set.
+
+Does not open SQLite. All ledger, governance, and run-history traffic goes to
+the control plane process.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from tokenops.control.models import (
+    BudgetSpec,
+    PolicyInstance,
+    RunAlreadyRegisteredError,
+    RunNotRegisteredError,
+    RunRecord,
+    RunRegistration,
+    Segment,
+    parse_governance_mode,
+)
+
+
+class HttpStore:
+    def __init__(self, base_url: str, *, api_key: str | None = None, timeout: float = 30.0) -> None:
+        self.path = base_url.rstrip("/")
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.Client(base_url=self.path, timeout=timeout, headers=headers)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        response = self._client.request(method, path, **kwargs)
+        if response.status_code == 409:
+            body = response.json()
+            raise RunAlreadyRegisteredError(body.get("error", "run already registered"))
+        if response.status_code == 404:
+            return response
+        response.raise_for_status()
+        return response
+
+    def register_run(self, reg: RunRegistration) -> RunRegistration:
+        r = self._request(
+            "POST",
+            "/v1/runs",
+            json={
+                "run_id": reg.run_id,
+                "intent": reg.intent,
+                "user_dims": dict(reg.user_dims),
+                "mode": reg.mode.value,
+            },
+        )
+        body = r.json()
+        return RunRegistration(
+            run_id=str(body["run_id"]),
+            intent=str(body.get("intent") or reg.intent),
+            user_dims={str(k): str(v) for k, v in (body.get("user_dims") or reg.user_dims).items()},
+            mode=parse_governance_mode(body.get("mode") or reg.mode),
+        )
+
+    def resolve_run(self, run_id: str) -> RunRegistration:
+        r = self._client.get(f"/v1/runs/{run_id}/registration")
+        if r.status_code == 404:
+            raise RunNotRegisteredError(f"run {run_id!r} is not registered")
+        r.raise_for_status()
+        body = r.json()
+        return RunRegistration(
+            run_id=str(body["run_id"]),
+            intent=str(body.get("intent", "")),
+            user_dims={str(k): str(v) for k, v in (body.get("user_dims") or {}).items()},
+            mode=parse_governance_mode(body.get("mode")),
+        )
+
+    def get_run_registration(self, run_id: str) -> RunRegistration | None:
+        try:
+            return self.resolve_run(run_id)
+        except RunNotRegisteredError:
+            return None
+
+    def governance_config_for(self, agent: str) -> dict:
+        return self._request("GET", f"/v1/governance/{agent}").json()
+
+    def create_run(self, rec: RunRecord) -> RunRecord:
+        payload = {
+            "run_id": rec.run_id,
+            "agent": rec.agent,
+            "status": rec.status,
+            "parent_run": rec.parent_run,
+            "parent_span": rec.parent_span,
+            "halt_reason": rec.halt_reason,
+            "detector": rec.detector,
+            "cost_micros": rec.cost_micros,
+            "steps": rec.steps,
+            "started_at": rec.started_at,
+            "ended_at": rec.ended_at,
+            "task": rec.task,
+            "dims": dict(rec.dims),
+            "governance_events": list(rec.governance_events or []),
+        }
+        self._request("PUT", "/v1/run-records", json=payload)
+        return rec
+
+    def update_run(self, run_id: str, **fields: Any) -> None:
+        self._request("PATCH", f"/v1/run-records/{run_id}", json=fields)
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        r = self._client.get(f"/v1/run-records/{run_id}")
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return _run(r.json())
+
+    def list_runs(self, *, problematic_only: bool = False, limit: int = 200) -> list[RunRecord]:
+        r = self._request(
+            "GET",
+            "/v1/run-records",
+            params={"problematic_only": problematic_only, "limit": limit},
+        )
+        return [_run(x) for x in r.json()]
+
+    def ledger_add_spent(self, budget_id: str, segment_key: str, period: str, delta: int) -> int:
+        r = self._request(
+            "POST",
+            "/v1/ledger/spent/add",
+            json={
+                "budget_id": budget_id,
+                "segment_key": segment_key,
+                "period": period,
+                "delta": delta,
+            },
+        )
+        return int(r.json()["spent_micros"])
+
+    def ledger_get_spent(self, budget_id: str, segment_key: str, period: str) -> int:
+        r = self._request(
+            "GET",
+            "/v1/ledger/spent",
+            params={"budget_id": budget_id, "segment_key": segment_key, "period": period},
+        )
+        return int(r.json()["spent_micros"])
+
+    def ledger_admit(self, segment_key: str) -> int:
+        r = self._request("POST", "/v1/ledger/inflight/admit", json={"segment_key": segment_key})
+        return int(r.json()["count"])
+
+    def ledger_complete(self, segment_key: str) -> int:
+        r = self._request("POST", "/v1/ledger/inflight/complete", json={"segment_key": segment_key})
+        return int(r.json()["count"])
+
+    def ledger_inflight(self, segment_key: str) -> int:
+        r = self._request("GET", "/v1/ledger/inflight", params={"segment_key": segment_key})
+        return int(r.json()["count"])
+
+    def ledger_mark_halted(self, run_id: str, reason: str = "") -> None:
+        self._request("POST", "/v1/ledger/halt/mark", json={"run_id": run_id, "reason": reason})
+
+    def ledger_is_halted(self, run_id: str) -> bool:
+        r = self._request("GET", f"/v1/ledger/halt/{run_id}")
+        return bool(r.json().get("halted"))
+
+    def ledger_halt_reason(self, run_id: str) -> str | None:
+        r = self._client.get(f"/v1/ledger/halt/{run_id}")
+        r.raise_for_status()
+        return r.json().get("halt_reason")
+
+    def ledger_clear_halt(self, run_id: str) -> None:
+        self._request("POST", "/v1/ledger/halt/clear", json={"run_id": run_id})
+
+    # Trajectory index is plane-local for now; no-ops keep policies from crashing.
+    def save_trajectory_snapshot(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def enqueue_trajectory_build(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def lookup_trajectory_index(self, **kwargs: Any) -> dict[str, Any] | None:
+        return None
+
+    def upsert_segment(self, seg: Segment) -> Segment:
+        self._request("PUT", "/v1/segments", json=seg.__dict__)
+        return seg
+
+    def list_segments(self) -> list[Segment]:
+        return [Segment(**x) for x in self._request("GET", "/v1/segments").json()]
+
+    def upsert_budget(self, b: BudgetSpec) -> BudgetSpec:
+        self._request("PUT", "/v1/budgets", json=b.__dict__)
+        return b
+
+    def list_budgets(self) -> list[BudgetSpec]:
+        return [BudgetSpec(**x) for x in self._request("GET", "/v1/budgets").json()]
+
+    def list_policy_instances(self) -> list[PolicyInstance]:
+        return [PolicyInstance(**x) for x in self._request("GET", "/v1/policies").json()]
+
+
+def _run(data: dict[str, Any]) -> RunRecord:
+    return RunRecord(
+        run_id=str(data["run_id"]),
+        agent=str(data["agent"]),
+        status=data.get("status", "running"),
+        parent_run=data.get("parent_run"),
+        parent_span=data.get("parent_span"),
+        halt_reason=data.get("halt_reason"),
+        detector=data.get("detector"),
+        cost_micros=int(data.get("cost_micros", 0)),
+        steps=int(data.get("steps", 0)),
+        started_at=float(data.get("started_at", 0.0)),
+        ended_at=data.get("ended_at"),
+        task=data.get("task"),
+        dims={str(k): str(v) for k, v in (data.get("dims") or {}).items()},
+        governance_events=list(data.get("governance_events") or []),
+    )


### PR DESCRIPTION
## Summary
- `ControlPlaneClient.from_env()` prefers `CONTROL_PLANE_URL` (then `TOKENOPS_URL`).
- Remote mode uses `HttpStore` for runs, governance, ledger, and run records — no local SQLite.
- `TOKENOPS_EMBEDDED=1` still uses the in-process Store.

Companion: control-plane PR (the process that owns SQLite).

## Test plan
- [ ] Pre-commit / mypy on this branch
- [ ] With `CONTROL_PLANE_URL` set, register a run and confirm it appears on the plane TokenOps tab
- [ ] Confirm no `tokenops.db` is created in remote mode


Made with [Cursor](https://cursor.com)