### PR TITLE
Release agent-tokenops 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- **HTTP store** when `CONTROL_PLANE_URL` or `TOKENOPS_URL` is set: runs, governance,
+  ledger, and run-records go to the AgentPlane control plane over HTTP (`HttpStore`).
+  No local SQLite in that mode. `CONTROL_PLANE_API_KEY` / `TOKENOPS_API_KEY` are sent
+  as Bearer on those requests.
+
 ## [0.1.3] - 2026-07-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-tokenops"
-version = "0.1.3"
+version = "0.2.0"
 description = "TokenOps control plane and SDK for run-aware agent token governance"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokenops/__init__.py
+++ b/src/tokenops/__init__.py
@@ -4,7 +4,7 @@ from tokenops.env import load_env
 
 load_env()
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 
 
 def init() -> None:


### PR DESCRIPTION
## Summary
- Bump `agent-tokenops` to **0.2.0** so PyPI can ship the HTTP control-plane store (`CONTROL_PLANE_URL` / `TOKENOPS_URL` + Bearer API key).

## Test plan
- [ ] CI green
- [ ] After merge: Actions → Release → Run workflow on `main`


Made with [Cursor](https://cursor.com)