### PR TITLE
README community and press links, plus an issue-first contributing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ cp .env.example .env  # optional API keys for live demos
 Install [Git LFS](https://git-lfs.com) if you need local copies of demo videos /
 the product deck (tracked as LFS pointers).
 
-Optional local hooks (same checks as CI — ruff + mypy):
+Optional local hooks (same checks as CI: ruff + mypy):
 
 ```bash
 pre-commit install
@@ -63,10 +63,20 @@ governance wraps, ledger, and the control-plane server.
 
 ## Pull requests
 
-1. Prefer a focused PR (one concern per change).
-2. Add or update tests when behavior changes.
-3. Run `make lint` and `make test` before opening the PR.
-4. Update `CHANGELOG.md` for user-visible changes (see `RELEASING.md`).
+**Open an issue first.** For anything beyond a typo or a small docs fix, file an
+issue describing the problem or the feature, and wait for a maintainer to agree
+on the approach before you write the patch. It keeps you from spending a weekend
+on a change we cannot merge, and it gives the PR something to close.
+
+1. Open an issue and get agreement on the approach.
+2. Branch, then keep the PR focused (one concern per change).
+3. Add or update tests when behavior changes.
+4. Run `make lint` and `make test` before opening the PR.
+5. Update `CHANGELOG.md` for user-visible changes (see `RELEASING.md`).
+6. Link the issue in the PR description (`Fixes #123`).
+
+Typos, broken links, and formatting fixes can skip step 1 and go straight to a
+pull request.
 
 ## Discussions vs issues
 
@@ -83,4 +93,5 @@ Use **Issues** for work that needs a patch:
 
 - Bug reports: expected vs actual behavior, minimal repro, versions.
 - Concrete, ready-to-implement features (problem statement first; link related docs).
-- Security: see [SECURITY.md](SECURITY.md) — do not file public issues or discussions for vulns.
+- The issue comes before the pull request, so the approach can be agreed there.
+- Security: see [SECURITY.md](SECURITY.md); do not file public issues or discussions for vulns.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Cap spend and steer behavior across a whole agent workflow — not per request �
 [![Discussions](https://img.shields.io/badge/GitHub-Discussions-7B61FF?style=flat)](https://github.com/theagentplane/tokenops/discussions)
 [![Slack](https://img.shields.io/badge/Slack-join%20the%20community-4A154B?style=flat&logo=slack&logoColor=white)](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)
 
-[![Featured by Microsoft Developer](https://img.shields.io/badge/Featured%20by-Microsoft%20Developer-0078D4?style=flat&logo=microsoft&logoColor=white)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
+[![Featured by Microsoft Developer](https://img.shields.io/badge/Featured%20by-Microsoft%20Developer-0078D4?style=flat&logo=microsoft&logoColor=white)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
+[![Command Line — a Microsoft publication](https://img.shields.io/badge/Command%20Line-Microsoft-5E5E5E?style=flat&logo=microsoft&logoColor=white)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
 [![Talk: AI Engineer World's Fair](https://img.shields.io/badge/Talk-AI%20Engineer%20World%27s%20Fair-FF0000?style=flat&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
 <br>
@@ -259,6 +260,8 @@ Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-
 
 ## Talks & press
 
+- **Featured by Microsoft Developer** — “Who spent all the tokens?” on
+  [LinkedIn](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b) and [X](https://x.com/msdev/status/2093425027500978292).
 - **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)** — *Command Line*, a Microsoft publication. Why per-request caps miss agent workflows, and how a run-scoped ledger plus in-path enforcement stops the bill mid-run.
 - **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)** — talk at the **AI Engineer World's Fair**, San Francisco. Live walkthrough of a governed multi-agent run hitting its budget cap.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # TokenOps
 
 **Run-aware token governance for multi-agent systems.**<br>
-Cap spend and steer behavior across a whole agent workflow — not per request — with a shared ledger and in-path enforcement.
+Cap spend and steer behavior across a whole agent workflow, not per request, with a shared ledger and in-path enforcement.
 
 <sub>Built by <b>Susheem Koul</b> and <b>Tisha Chawla</b></sub>
 
@@ -17,7 +17,7 @@ Cap spend and steer behavior across a whole agent workflow — not per request �
 [![Slack](https://img.shields.io/badge/Slack-join%20the%20community-4A154B?style=flat&logo=slack&logoColor=white)](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)
 
 [![Featured by Microsoft Developer](https://img.shields.io/badge/Featured%20by-Microsoft%20Developer-0078D4?style=flat&logo=microsoft&logoColor=white)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
-[![Command Line — a Microsoft publication](https://img.shields.io/badge/Command%20Line-Microsoft-5E5E5E?style=flat&logo=microsoft&logoColor=white)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
+[![Command Line, a Microsoft publication](https://img.shields.io/badge/Command%20Line-Microsoft-5E5E5E?style=flat&logo=microsoft&logoColor=white)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
 [![Talk: AI Engineer World's Fair](https://img.shields.io/badge/Talk-AI%20Engineer%20World%27s%20Fair-FF0000?style=flat&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
 <br>
@@ -32,7 +32,7 @@ Cap spend and steer behavior across a whole agent workflow — not per request �
 
 <br>
 
-TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a run; every LLM and tool crossing shares one `run_id` and one ledger. Policies can halt, mutate, or inject before the next call executes — so a research → summarize → review pipeline stays inside a single budget even across processes.
+TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a run; every LLM and tool crossing shares one `run_id` and one ledger. Policies can halt, mutate, or inject before the next call executes, so a research → summarize → review pipeline stays inside a single budget even across processes.
 
 **[Why](#why-tokenops) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Onboarding](docs/guides/onboarding.md) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Make targets](#make-targets) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
 
@@ -41,7 +41,7 @@ TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a 
 - **Govern the run, not the request.** One `run_id` spans every model, tool, and A2A hop in a workflow.
 - **Shared ledger across processes.** Spend, inflight, and halt live in SQLite so multi-agent stacks cannot each burn the full cap locally.
 - **In-path enforcement.** `wrap_complete` runs detect → decide → apply *before* the next LLM call; Chronicle `@boundary` + a crossing hook ingest tool spend.
-- **Steer or stop.** Actuators: `HALT` · `MUTATE` · `INJECT` · reject/queue — not just post-hoc analytics.
+- **Steer or stop.** Actuators: `HALT` · `MUTATE` · `INJECT` · reject/queue, not just post-hoc analytics.
 - **Batteries included.** Control plane (`:7700`), Admin + Dashboard UI, ten seeded policies, and runnable A2A benches (two-agent, triad, LangChain brief).
 
 ## Architecture
@@ -175,7 +175,7 @@ See [`examples/README.md`](examples/README.md) and [`docs/control-plane-deploy.m
 
 ## How TokenOps compares
 
-TokenOps is not a gateway or a tracing dashboard. It governs the **run** — a full agent workflow — and sits alongside the tools you already use for routing and observability.
+TokenOps is not a gateway or a tracing dashboard. It governs the **run**, a full agent workflow, and sits alongside the tools you already use for routing and observability.
 
 | | TokenOps | LiteLLM / Portkey / AI Gateway | Langfuse |
 |---|:---:|:---:|:---:|
@@ -249,8 +249,8 @@ Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-
 
 ## Documentation
 
-- [Onboarding](docs/guides/onboarding.md) — prereqs, bare-min integrate, FAQ, current limits
-- [Field guide](docs/guides/field-guide-add-tokenops.md) — triad deep dive + screenshots
+- [Onboarding](docs/guides/onboarding.md): prereqs, bare-min integrate, FAQ, current limits
+- [Field guide](docs/guides/field-guide-add-tokenops.md): triad deep dive + screenshots
 - [Control plane status](docs/control-plane-status.md)
 - [Architecture](docs/architecture.md)
 - [Run attribution](docs/run-attribution.md)
@@ -260,15 +260,15 @@ Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-
 
 ## Talks & press
 
-- **Featured by Microsoft Developer** — “Who spent all the tokens?” on
+- **Featured by Microsoft Developer**: “Who spent all the tokens?” on
   [LinkedIn](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b) and [X](https://x.com/msdev/status/2093425027500978292).
-- **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)** — *Command Line*, a Microsoft publication. Why per-request caps miss agent workflows, and how a run-scoped ledger plus in-path enforcement stops the bill mid-run.
-- **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)** — talk at the **AI Engineer World's Fair**, San Francisco. Live walkthrough of a governed multi-agent run hitting its budget cap.
+- **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)**: *Command Line*, a Microsoft publication. Why per-request caps miss agent workflows, and how a run-scoped ledger plus in-path enforcement stops the bill mid-run.
+- **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)**: talk at the **AI Engineer World's Fair**, San Francisco. Live walkthrough of a governed multi-agent run hitting its budget cap.
 
 ## Community
 
-Join the Slack workspace — **[The Agent Plane on Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)** — for real-time questions,
-integration help, and demos of what you have governed.
+**[Join The Agent Plane on Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)**
+for real-time questions, integration help, and demos of what you have governed.
 
 For longer-form questions, ideas, and show-and-tell, use
 [GitHub Discussions](https://github.com/theagentplane/tokenops/discussions).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Cap spend and steer behavior across a whole agent workflow, not per request, wit
 
 TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a run; every LLM and tool crossing shares one `run_id` and one ledger. Policies can halt, mutate, or inject before the next call executes, so a research → summarize → review pipeline stays inside a single budget even across processes.
 
-**[Why](#why-tokenops) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Onboarding](docs/guides/onboarding.md) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Make targets](#make-targets) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
+**[Why](#why-tokenops) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
 
 ## Why TokenOps
 
@@ -141,9 +141,9 @@ make control-plane               # :7700
 make ui                          # Admin + Dashboard :8501
 ```
 
-New here? [Onboarding guide](docs/guides/onboarding.md) (prereqs, bare-min integrate, FAQ, current limits).
-
-Full integration checklist: [`.cursor/skills/integrate-tokenops/SKILL.md`](.cursor/skills/integrate-tokenops/SKILL.md) · triad deep dive: [`docs/guides/field-guide-add-tokenops.md`](docs/guides/field-guide-add-tokenops.md).
+New here? Start with the [onboarding guide](docs/guides/onboarding.md), then the
+[integration checklist](.cursor/skills/integrate-tokenops/SKILL.md) or the
+[triad field guide](docs/guides/field-guide-add-tokenops.md).
 
 ## Demos
 
@@ -155,12 +155,6 @@ Each bench is a multi-agent stack with a shared run ledger. Start the plane, age
 | Triad | Planner → Researcher → Writer | `make demo-triad` |
 | Brief | Scout → Analyst → Editor (LangChain) | `make demo-brief` |
 | Bench UI | Chat + Simulator only | `make bench-ui` |
-
-```bash
-make demo              # plane + research/summarize + Admin UI
-make demo-triad        # plane + planner/researcher/writer
-make demo-brief        # plane + scout/analyst/editor
-```
 
 Docker:
 
@@ -185,7 +179,7 @@ TokenOps is not a gateway or a tracing dashboard. It governs the **run**, a full
 | Steer next call (mutate / inject) | Yes | Routing / fallbacks | No |
 | Shared ledger across agent processes | Yes | N/A | N/A |
 
-What this does **not** do: replace your LLM gateway, replace Chronicle-style record-and-replay, or host a SaaS control plane for you. Fail-closed integrity (refuse on missing registration) is optional and upcoming.
+What this does **not** do: replace your LLM gateway, replace Chronicle-style record-and-replay, or host a SaaS control plane for you.
 
 Longer table with logos: [`docs/product/comparison.md`](docs/product/comparison.md).
 
@@ -241,11 +235,11 @@ tests/                     # unit + e2e
 TokenOps is early (0.x). Near-term:
 
 - User/tag segment-scoped budgets (machinery exists; seed is run-only today).
-- Optional fail-closed mode on missing registration or exceeded budget.
+- Optional fail-closed integrity: refuse on missing registration or exceeded budget.
 - Remote observe / decide (fatter plane) for multi-host stacks.
 - Documentation site.
 
-Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-plane-status.md). Ideas welcome in [GitHub Discussions](https://github.com/theagentplane/tokenops/discussions).
+Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-plane-status.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 **Run-aware token governance for multi-agent systems.**<br>
 Cap spend and steer behavior across a whole agent workflow — not per request — with a shared ledger and in-path enforcement.
 
+<sub>Built by <b>Susheem Koul</b> and <b>Tisha Chawla</b></sub>
+
 [![CI](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-tokenops.svg)](https://pypi.org/project/agent-tokenops/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://github.com/theagentplane/tokenops)
@@ -12,6 +14,10 @@ Cap spend and steer behavior across a whole agent workflow — not per request �
 [![Status](https://img.shields.io/badge/status-0.x%20%7C%20draft-7B61FF?style=flat-square)](https://semver.org/)
 [![Stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=flat&color=yellow)](https://github.com/theagentplane/tokenops/stargazers)
 [![Discussions](https://img.shields.io/badge/GitHub-Discussions-7B61FF?style=flat)](https://github.com/theagentplane/tokenops/discussions)
+[![Slack](https://img.shields.io/badge/Slack-join%20the%20community-4A154B?style=flat&logo=slack&logoColor=white)](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)
+
+[![Featured by Microsoft Developer](https://img.shields.io/badge/Featured%20by-Microsoft%20Developer-0078D4?style=flat&logo=microsoft&logoColor=white)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
+[![Talk: AI Engineer World's Fair](https://img.shields.io/badge/Talk-AI%20Engineer%20World%27s%20Fair-FF0000?style=flat&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
 <br>
 
@@ -27,7 +33,7 @@ Cap spend and steer behavior across a whole agent workflow — not per request �
 
 TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a run; every LLM and tool crossing shares one `run_id` and one ledger. Policies can halt, mutate, or inject before the next call executes — so a research → summarize → review pipeline stays inside a single budget even across processes.
 
-**[Why](#why-tokenops) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Onboarding](docs/guides/onboarding.md) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Make targets](#make-targets) · [Roadmap](#roadmap)**
+**[Why](#why-tokenops) · [Architecture](#architecture) · [Install](#install) · [Quick start](#quick-start) · [Onboarding](docs/guides/onboarding.md) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Make targets](#make-targets) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
 
 ## Why TokenOps
 
@@ -251,9 +257,21 @@ Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-
 - [Examples](examples/README.md)
 - [Product: comparison](docs/product/comparison.md) · [shared ledger](docs/product/shared-ledger.md)
 
+## Talks & press
+
+- **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)** — *Command Line*, a Microsoft publication. Why per-request caps miss agent workflows, and how a run-scoped ledger plus in-path enforcement stops the bill mid-run.
+- **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)** — talk at the **AI Engineer World's Fair**, San Francisco. Live walkthrough of a governed multi-agent run hitting its budget cap.
+
+## Community
+
+Join the Slack workspace — **[The Agent Plane on Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)** — for real-time questions,
+integration help, and demos of what you have governed.
+
+For longer-form questions, ideas, and show-and-tell, use
+[GitHub Discussions](https://github.com/theagentplane/tokenops/discussions).
+
 ## Contributing
 
-Questions, ideas, and show-and-tell belong in [Discussions](https://github.com/theagentplane/tokenops/discussions).
 Bugs and pull requests belong in Issues. See [CONTRIBUTING.md](CONTRIBUTING.md),
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [SECURITY.md](SECURITY.md).
 
@@ -275,6 +293,6 @@ If TokenOps saves you a runaway agent bill, please [⭐ star the repo](https://g
 
 <div align="center">
 
-Built by Susheem Koul and Tisha Chawla
+[Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg) · [Discussions](https://github.com/theagentplane/tokenops/discussions) · [PyPI](https://pypi.org/project/agent-tokenops/)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ For longer-form questions, ideas, and show-and-tell, use
 
 ## Contributing
 
-Bugs and pull requests belong in Issues. See [CONTRIBUTING.md](CONTRIBUTING.md),
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [SECURITY.md](SECURITY.md).
+Bugs belong in Issues. Open an issue before a pull request so the approach can
+be agreed there first; typos and small docs fixes can go straight to a PR. See
+[CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md),
+and [SECURITY.md](SECURITY.md).
 
 ```bash
 make install


### PR DESCRIPTION
Docs only. No code, tests, or workflow files touched.

### Community and press links (README)

- **Slack** badge plus a new **Community** section with the join link for The
  Agent Plane workspace. Slack is the real-time channel; Discussions stays the
  home for longer-form questions.
- **Featured by Microsoft Developer** badge linking the Microsoft Developer
  feature ([LinkedIn](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b) ·
  [X](https://x.com/msdev/status/2093425027500978292)).
- **Command Line** badge linking ["Who spent all the tokens? Real-time,
  run-scoped cost control for AI agents"](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
  (*Command Line*, a Microsoft publication).
- **AI Engineer World's Fair** badge for the talk
  ["FinOps for AI Agents: Who Spent All the Tokens?"](https://www.youtube.com/watch?v=GJX19pNhmSw).
- New **Talks & press** section holding all three, linked from the top nav.
- **Built by** byline moved up under the tagline; the closing centered block is
  now Slack · Discussions · PyPI.

### Editing pass (README)

- Every em dash replaced with a comma or a colon.
- Nav line lists README sections only; onboarding and the make-target reference
  are linked where they are actually used.
- The two "new here" pointer lines merged into one.
- Dropped the bash block under Demos that repeated the demo table's targets.
- Fail-closed integrity stated once, in the roadmap, instead of twice.
- Discussions linked from Community rather than from Roadmap as well.
- All relative links verified to resolve.

### Contributing

- `CONTRIBUTING.md`: issue-first workflow. Open an issue and agree the approach
  before writing the patch, link it from the PR (`Fixes #123`), with typos and
  small docs fixes exempt.
- One-line pointer to the same rule from the README's Contributing section.
- `CODE_OF_CONDUCT.md` is untouched: it is the Contributor Covenant, and process
  rules belong in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
