### PR TITLE
Add office hours to the README Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ for real-time questions, integration help, and demos of what you have governed.
 For longer-form questions, ideas, and show-and-tell, use
 [GitHub Discussions](https://github.com/theagentplane/tokenops/discussions).
 
+**Office hours:** if you are wiring TokenOps into a real stack and want to talk it
+through, [book a slot](https://calendly.com/theagentplane/theagentplane).
+
 ## Contributing
 
 Bugs belong in Issues. Open an issue before a pull request so the approach can


### PR DESCRIPTION
Adds an office-hours line to **Community**, under Slack and Discussions:

> **Office hours:** if you are wiring TokenOps into a real stack and want to talk
> it through, [book a slot](https://calendly.com/theagentplane/theagentplane).

The Community section now reads as three escalating channels: Slack for quick
questions, Discussions for longer threads, a call when someone is doing a real
integration.

README only. One paragraph added, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
