### PR TITLE
Keep governance reasons ASCII so they cannot crash a Windows console

### DIFF
--- a/src/tokenops/control/policies/concurrency_cap.py
+++ b/src/tokenops/control/policies/concurrency_cap.py
@@ -52,7 +52,7 @@ class ConcurrencyCapDetector(Detector):
                 detector=self.name,
                 severity=Severity.TRIP,
                 run_id=request.attr.run_id,
-                reason=f"inflight {n} ≥ max_concurrent {self.max_concurrent} on {sk}",
+                reason=f"inflight {n} >= max_concurrent {self.max_concurrent} on {sk}",
                 evidence={"inflight": n, "max": self.max_concurrent, "segment": sk},
             )
         return None

--- a/src/tokenops/control/policies/context_compaction.py
+++ b/src/tokenops/control/policies/context_compaction.py
@@ -77,7 +77,7 @@ class ContextCompactionPolicy(Policy):
             return Action(
                 kind=ActionKind.ALLOW,
                 run_id=signal.run_id,
-                reason=f"{signal.reason} (no assembly hook — telemetry only)",
+                reason=f"{signal.reason} (no assembly hook: telemetry only)",
             )
         return Action(
             kind=ActionKind.MUTATE,

--- a/src/tokenops/control/policies/cost_guard.py
+++ b/src/tokenops/control/policies/cost_guard.py
@@ -75,7 +75,7 @@ class CostGuardDetector(Detector):
                 detector=self.name,
                 severity=Severity.WARN,
                 run_id=attr.run_id,
-                reason=f"spend at {ratio:.0%} of budget (vel {vel:.0f}/step) — minimizing",
+                reason=f"spend at {ratio:.0%} of budget (vel {vel:.0f}/step), minimizing",
                 evidence={"ratio": ratio, "velocity": vel},
             )
         return None

--- a/src/tokenops/control/policies/output_runaway.py
+++ b/src/tokenops/control/policies/output_runaway.py
@@ -56,7 +56,7 @@ class OutputRunawayDetector(Detector):
                 detector=self.name,
                 severity=Severity.WARN,
                 run_id=attr.run_id,
-                reason=f"degenerate output: ngram×{rep}, domination {dom:.0%}",
+                reason=f"degenerate output: ngram x{rep}, domination {dom:.0%}",
                 evidence={"ngram_repeat": rep, "domination": dom},
             )
         return None

--- a/src/tokenops/control/policies/pre_call_worst_case.py
+++ b/src/tokenops/control/policies/pre_call_worst_case.py
@@ -78,7 +78,7 @@ class PreCallWorstCaseDetector(Detector):
                 detector=self.name,
                 severity=Severity.TRIP,
                 run_id=request.attr.run_id,
-                reason=f"worst-case {projected} ≥ remaining budget {left} (micros)",
+                reason=f"worst-case {projected} >= remaining budget {left} (micros)",
                 evidence={"projected": projected, "left": left, "capped_out": capped_out},
             )
         if request.max_output_tokens is None:

--- a/src/tokenops/control/policies/progress_guard.py
+++ b/src/tokenops/control/policies/progress_guard.py
@@ -108,7 +108,7 @@ class ProgressGuardPolicy(Policy):
             return Action(
                 kind=ActionKind.HALT,
                 run_id=signal.run_id,
-                reason=f"progress_guard: {signal.evidence['correction']} corrections, no progress — halting",
+                reason=f"progress_guard: {signal.evidence['correction']} corrections, no progress, halting",
             )
         return Action(
             kind=ActionKind.INJECT,

--- a/src/tokenops/control/policies/step_cap.py
+++ b/src/tokenops/control/policies/step_cap.py
@@ -40,7 +40,7 @@ class StepCapDetector(Detector):
                 detector=self.name,
                 severity=Severity.TRIP,
                 run_id=attr.run_id,
-                reason=f"step cap reached: {step.step} ≥ {self.max_steps}",
+                reason=f"step cap reached: {step.step} >= {self.max_steps}",
                 evidence={"steps": step.step, "max_steps": self.max_steps},
             )
         return None

--- a/src/tokenops/control/policies/tool_fix.py
+++ b/src/tokenops/control/policies/tool_fix.py
@@ -90,7 +90,7 @@ class ToolFixPolicy(Policy):
             return Action(
                 kind=ActionKind.HALT,
                 run_id=signal.run_id,
-                reason=f"tool_fix: {signal.evidence['count']} identical bad calls — halting",
+                reason=f"tool_fix: {signal.evidence['count']} identical bad calls, halting",
             )
         ev = signal.evidence
         hint = f" did_you_mean={ev['did_you_mean']}" if ev.get("did_you_mean") else ""

--- a/src/tokenops/control/policies/tool_output_cap.py
+++ b/src/tokenops/control/policies/tool_output_cap.py
@@ -58,7 +58,7 @@ class ToolOutputCapDetector(Detector):
                 detector=self.name,
                 severity=Severity.WARN,
                 run_id=attr.run_id,
-                reason=f"tool '{step.boundary_id}' output ≈{est} tokens ≥ cap {self.cap_tokens}",
+                reason=f"tool '{step.boundary_id}' output ~{est} tokens >= cap {self.cap_tokens}",
                 evidence={
                     "est_tokens": est,
                     "cap": self.cap_tokens,

--- a/tests/test_reason_encoding.py
+++ b/tests/test_reason_encoding.py
@@ -1,0 +1,78 @@
+"""Governance reasons must survive a legacy console encoding.
+
+A ``reason`` is user-facing: it is printed, logged, and shown in the Dashboard.
+On Windows, stdout defaults to cp1252 whenever it is redirected, which covers
+piping to a file and most CI runners. A single non-ASCII character in a reason
+turns a correct governance decision into a ``UnicodeEncodeError`` that kills the
+process, so the enforcement works and the report of it crashes.
+
+This guards the source rather than waiting for a policy to trip, because a
+reason is only built on the path that trips it and most paths are rare.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parent.parent / "src" / "tokenops"
+Failed = pytest.fail.Exception
+LEGACY_ENCODING = "cp1252"
+
+
+def _reason_strings(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Every literal text passed as ``reason=``, including inside f-strings."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "reason":
+                continue
+            if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                found.append((kw.value.lineno, kw.value.value))
+            elif isinstance(kw.value, ast.JoinedStr):
+                # An f-string: only the literal segments can carry a stray glyph.
+                for part in kw.value.values:
+                    if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                        found.append((kw.value.lineno, part.value))
+    return found
+
+
+POLICY_FILES = sorted((SRC / "control" / "policies").glob("*.py"))
+
+
+@pytest.mark.parametrize("path", POLICY_FILES, ids=lambda p: p.name)
+def test_policy_reasons_encode_on_a_legacy_console(path: pathlib.Path) -> None:
+    """Use >= not U+2265, ~ not U+2248, x not U+00D7, and a comma not an em dash."""
+    for lineno, text in _reason_strings(path):
+        try:
+            text.encode(LEGACY_ENCODING)
+        except UnicodeEncodeError as exc:
+            bad = text[exc.start : exc.end]
+            pytest.fail(
+                f"{path.name}:{lineno} reason contains {bad!r} "
+                f"(U+{ord(bad[0]):04X}), which raises UnicodeEncodeError on a "
+                f"{LEGACY_ENCODING} console. Use an ASCII equivalent."
+            )
+
+
+def test_the_guard_actually_looks_at_something() -> None:
+    """A silent zero-match scan would pass forever. Assert it found real reasons."""
+    total = sum(len(_reason_strings(p)) for p in POLICY_FILES)
+    assert len(POLICY_FILES) >= 10, "policy modules disappeared; fix this test's glob"
+    assert total >= 10, f"expected many reason= strings across policies, found {total}"
+
+
+def test_the_guard_catches_a_reintroduction(tmp_path: pathlib.Path) -> None:
+    """The check must fail on the exact pattern that was removed."""
+    offender = tmp_path / "bad_policy.py"
+    offender.write_text(
+        'Signal(reason=f"step cap reached: {n} ≥ {cap}")\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(Failed):
+        test_policy_reasons_encode_on_a_legacy_console(offender)


### PR DESCRIPTION
Closes #65.

## The bug

Nine policies built their `reason` string with a non-ASCII glyph (`≥`, `—`, `×`, `≈`). A reason is user-facing: printed, logged, and shown in the Dashboard. On Windows, stdout defaults to **cp1252** whenever it is redirected, which covers piping to a file and most CI runners. Encoding one of those raises `UnicodeEncodeError` and kills the process.

The governance decision was correct. Reporting it is what crashed.

```
$ PYTHONIOENCODING=cp1252 python -c "print('step cap reached: 4 \u2265 3')"
UnicodeEncodeError: 'charmap' codec can't encode character '\u2265'
in position 20: character maps to <undefined>
```

Same through `logging`, which is how a server surfaces these.

## The change

| Policy | Was | Now |
|---|---|---|
| `concurrency_cap` | `≥` U+2265 | `>=` |
| `context_compaction` | `—` U+2014 | `:` |
| `cost_guard` | `—` U+2014 | `,` |
| `output_runaway` | `×` U+00D7 | `x` |
| `pre_call_worst_case` | `≥` U+2265 | `>=` |
| `progress_guard` | `—` U+2014 | `,` |
| `step_cap` | `≥` U+2265 | `>=` |
| `tool_fix` | `—` U+2014 | `,` |
| `tool_output_cap` | `≈` U+2248, `≥` U+2265 | `~`, `>=` |

Wording is otherwise unchanged. Scope is `reason=` strings only; docstrings and comments never reach the console.

## The guard

`tests/test_reason_encoding.py` walks each policy module's **AST**, collects every literal passed as `reason=` (including the literal segments of f-strings), and asserts it encodes to cp1252.

It checks the source rather than waiting for a policy to trip, because a reason is only built on the path that trips it and most of those paths are rare. Two meta-tests keep the guard honest:

- one fails if the scan ever silently stops finding reasons,
- one feeds it the exact removed pattern to prove it still catches a reintroduction.

## Verification

Windows, Python 3.10. Tripping `step_cap` for real under `PYTHONIOENCODING=cp1252`:

```
REASON: step cap reached: 4 >= 3
```

Before this change that same call raised `UnicodeEncodeError`.

- `ruff check` clean, `ruff format --check` clean on 206 files
- `mypy` clean on 54 source files
- `pytest`: **203 passed, 3 skipped, 11 deselected**

No test or doc asserted on the old literal text, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)