### PR TITLE
Fold Demos into Run it locally and make the target table the one command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ run, so later calls on the same `run_id` are refused, even from another process.
 
 TokenOps is a **control plane + SDK** for agent stacks. Entry agents register a run; every LLM and tool crossing shares one `run_id` and one ledger. Policies can halt, mutate, or inject before the next call executes, so a research → summarize → review pipeline stays inside a single budget even across processes.
 
-**[Why](#why-tokenops) · [Architecture](#architecture) · [Run it locally](#run-it-locally) · [Demos](#demos) · [Comparison](#how-tokenops-compares) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
+**[Why](#why-tokenops) · [Architecture](#architecture) · [Run it locally](#run-it-locally) · [Comparison](#how-tokenops-compares) · [Roadmap](#roadmap) · [Talks & press](#talks--press) · [Community](#community)**
 
 ## Why TokenOps
 
@@ -183,27 +183,22 @@ PyPI name is `agent-tokenops`; the import is `tokenops`. Extras:
 `pip install "agent-tokenops[examples]"` for the LangChain benches,
 `".[dev,examples]"` from source. Releases: [`RELEASING.md`](RELEASING.md).
 
-## Demos
+### Multi-agent benches
 
-Each bench is a multi-agent stack with a shared run ledger. Start the plane, agents, and Admin UI with one make target.
+Each is a real multi-agent stack sharing one run ledger, so you can watch a
+single budget span several agents. One target starts the plane, the agents and
+the Admin UI.
 
-| Demo | Agents | Run |
+| Bench | Agents | Run |
 |---|---|---|
-| Two-agent | Research → Summarize | `make demo` |
-| Triad | Planner → Researcher → Writer | `make demo-triad` |
-| Brief | Scout → Analyst → Editor (LangChain) | `make demo-brief` |
+| Two-agent | Research to Summarize | `make demo` |
+| Triad | Planner to Researcher to Writer | `make demo-triad` |
+| Brief | Scout to Analyst to Editor (LangChain) | `make demo-brief` |
 | Bench UI | Chat + Simulator only | `make bench-ui` |
 
-Docker:
-
-```bash
-docker compose up --build
-# optional UI: docker compose --profile ui up --build
-# two-agent stack:
-docker compose -f docker-compose.examples.yml up --build
-```
-
-See [`examples/README.md`](examples/README.md) and [`docs/control-plane-deploy.md`](docs/control-plane-deploy.md).
+Docker instead of make: `docker compose up --build`, and see
+[`docs/control-plane-deploy.md`](docs/control-plane-deploy.md) for the UI and
+two-agent profiles. More on the benches: [`examples/README.md`](examples/README.md).
 
 ## How TokenOps compares
 
@@ -233,10 +228,12 @@ Longer table with logos: [`docs/product/comparison.md`](docs/product/comparison.
 | `make control-plane` | Standalone plane (`python -m tokenops.server`) on `:7700` |
 | `make ui` | Admin + Dashboard on `:8501` |
 | `make run` | Plane + Admin/Dashboard |
+| `make quickstart` | The one-file example: no API keys, no server |
 | `make demo` / `demo-triad` / `demo-brief` | Runnable A2A stacks |
 | `make bench-ui` | Chat + Simulator |
 | `make db-reset` | Clear SQLite + reseed from `TOKENOPS_CONFIG` |
 | `make stop` | Kill listeners on `:7700` / `:8501` |
+| `make sync-skills` | Regenerate the editor copies of the integration skill |
 
 </details>
 


### PR DESCRIPTION
Answering "can we remove the demo from the README, is it required?" with two different answers, because there are two things called demo.

## The GIF at the top: keep it

It is the only thing on the page that shows the product working before a reader has read a word, and it demonstrates the headline claim directly: a governed run halting mid-flight on its budget. Chronicle leads with one too, and so do the highest-traffic repos in this category. Removing it would be a clear downgrade for a page whose problem is that people bounce.

## The `## Demos` section: yes, fold it

Three sections told a reader how to start something. Counting occurrences in the README before this change:

| Command | Appearances |
|---|---|
| `make demo` and friends | Demos **and** Make targets |
| `docker compose` | **3** |
| `make install` | 3 |

- Delete the standalone **Demos** section. Its one piece of unique information, what each bench actually contains, moves to a **Multi-agent benches** subsection under *Run it locally*, right next to the commands that start them.
- Keep **one** docker line pointing at `docs/control-plane-deploy.md` instead of repeating three compose invocations that doc already covers. `docker compose`: 3 → 1.
- **Make targets** stays the single full command reference, and now lists `make quickstart` and `make sync-skills`, which were added in #64 but never documented in the table.
- Drop the dangling `Demos` entry from the nav line. Checked: no other file linked `#demos`.

Net 360 → 357 lines, with the duplication gone rather than the content.

## Verified

- Every target named in the table exists in the Makefile (checked, not assumed).
- No dangling `#demos` anchors anywhere in the repo.
- `pytest`: 203 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)