### PR TITLE
Merge concurrent policy actions instead of letting the last one win

### DIFF
--- a/src/tokenops/control/engine.py
+++ b/src/tokenops/control/engine.py
@@ -107,6 +107,17 @@ class ApplyControls:
       * MUTATE  → ``call`` overrides (model swap, output cap) + any prompt directive carried
       * INJECT  → ``carry`` messages appended as final user turns on the next dispatch
       * RETRY   → ``retry`` flag (the wrap may re-issue; streaming CANCEL is out of scope here)
+
+    One ``observe`` pass can hand several policies' actions to the same call, so this
+    connector merges rather than overwrites. Two rules keep that merge safe:
+
+    **Caps only tighten.** ``max_output_tokens`` takes the ``min`` of what any policy asked
+    for. Without this, a looser cap applied later silently undoes a tighter one, and the
+    order is severity rank then detector registration, which no user controls.
+
+    **Directives are bounded.** ``carry`` dedups and stops at ``max_carry``. ``cost_guard``
+    fires *because* spend is high, so an unbounded pile of steer messages would add prompt
+    tokens at exactly the wrong moment.
     """
 
     carry: list[str] = field(default_factory=list)
@@ -114,12 +125,15 @@ class ApplyControls:
     call: _ResolvedCall = field(default_factory=_ResolvedCall)
     retry: bool = False
     tool_result_override: str | None = None  # deep INJECT: substitute the last tool result
+    max_carry: int = 3  # steer messages carried onto one dispatch; the rest are dropped
+    dropped_carry: int = 0  # how many were dropped, for the dashboard
 
     def begin_call(self) -> None:
         """Reset per-call mutation state before a pre_call pass (``carry`` persists across
         calls until consumed by the next dispatch)."""
         self.call = _ResolvedCall()
         self.retry = False
+        self.dropped_carry = 0
 
     def take_tool_result(self) -> str | None:
         """Consume a pending tool-result substitution (the agent calls this after a tool
@@ -141,19 +155,38 @@ class ApplyControls:
             if action.downgrade_to:
                 self.call.model_override = action.downgrade_to
             if action.max_output_tokens is not None:
-                self.call.max_output_tokens = action.max_output_tokens
+                self._tighten_output_cap(action.max_output_tokens)
             if action.compact:  # deep prompt compaction (rewrite messages in the wrap)
                 self.call.compact = True
             if action.inject_message:  # compaction directive / steer
-                self.carry.append(action.inject_message)
+                self._carry(action.inject_message)
         elif kind is ActionKind.INJECT:
             if action.replace_tool_result and action.inject_message:  # deep tool-result swap
                 self.tool_result_override = action.inject_message
             elif action.inject_message:
-                self.carry.append(action.inject_message)
+                self._carry(action.inject_message)
         elif kind is ActionKind.RETRY:
             self.retry = True
         # CANCEL is stream-only; a synchronous wrap has nothing to tear down.
+
+    def _tighten_output_cap(self, requested: int) -> None:
+        """Take the tightest cap any policy asked for on this call.
+
+        Never widen: a policy asking for a bigger cap than one already set is asking to
+        undo another policy's restriction, and the winner would otherwise be decided by
+        detector registration order.
+        """
+        current = self.call.max_output_tokens
+        self.call.max_output_tokens = requested if current is None else min(current, requested)
+
+    def _carry(self, message: str) -> None:
+        """Queue a steer message, deduped and bounded by ``max_carry``."""
+        if message in self.carry:
+            return
+        if len(self.carry) >= self.max_carry:
+            self.dropped_carry += 1
+            return
+        self.carry.append(message)
 
 
 @dataclass

--- a/tests/test_policy_coordination.py
+++ b/tests/test_policy_coordination.py
@@ -1,0 +1,125 @@
+"""Several policies can act on one call. Their actions must merge, not fight.
+
+``Governor._enforce`` sorts signals by severity and then applies every one of them,
+so a single ``observe`` pass can hand ``ApplyControls`` a MUTATE from ``cost_guard``
+and another from ``pre_call_worst_case``. Which lands last is decided by severity
+rank and then detector registration order, neither of which a user controls, so the
+connector has to merge deterministically instead of overwriting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenops.control import ApplyControls
+from tokenops.control.core import Action, ActionKind
+
+
+def mutate(**kw) -> Action:
+    return Action(kind=ActionKind.MUTATE, run_id="r", **kw)
+
+
+def inject(message: str, **kw) -> Action:
+    return Action(kind=ActionKind.INJECT, run_id="r", inject_message=message, **kw)
+
+
+class TestOutputCapOnlyTightens:
+    """A later, looser cap must not undo an earlier, tighter one."""
+
+    def test_looser_cap_applied_second_does_not_widen(self):
+        c = ApplyControls()
+        c.apply(mutate(max_output_tokens=256))  # cost_guard tightening under pressure
+        c.apply(mutate(max_output_tokens=1024))  # pre_call_worst_case default cap
+        assert c.call.max_output_tokens == 256
+
+    def test_tighter_cap_applied_second_does_tighten(self):
+        c = ApplyControls()
+        c.apply(mutate(max_output_tokens=1024))
+        c.apply(mutate(max_output_tokens=256))
+        assert c.call.max_output_tokens == 256
+
+    def test_order_does_not_change_the_outcome(self):
+        """The whole point: the result cannot depend on registration order."""
+        caps = [512, 128, 2048, 256]
+        first = ApplyControls()
+        for cap in caps:
+            first.apply(mutate(max_output_tokens=cap))
+        second = ApplyControls()
+        for cap in reversed(caps):
+            second.apply(mutate(max_output_tokens=cap))
+        assert first.call.max_output_tokens == second.call.max_output_tokens == 128
+
+    def test_first_cap_still_sets_the_value(self):
+        c = ApplyControls()
+        c.apply(mutate(max_output_tokens=700))
+        assert c.call.max_output_tokens == 700
+
+    def test_begin_call_clears_the_cap_for_the_next_call(self):
+        c = ApplyControls()
+        c.apply(mutate(max_output_tokens=128))
+        c.begin_call()
+        c.apply(mutate(max_output_tokens=4096))
+        assert c.call.max_output_tokens == 4096
+
+
+class TestCarryIsBounded:
+    """cost_guard fires because spend is high. Steer messages must not pile up."""
+
+    def test_duplicate_directives_are_not_repeated(self):
+        c = ApplyControls()
+        c.apply(inject("BUDGET PRESSURE: keep responses minimal."))
+        c.apply(inject("BUDGET PRESSURE: keep responses minimal."))
+        assert c.carry == ["BUDGET PRESSURE: keep responses minimal."]
+        assert c.dropped_carry == 0
+
+    def test_carry_stops_at_max_carry_and_counts_drops(self):
+        c = ApplyControls(max_carry=2)
+        for i in range(5):
+            c.apply(inject(f"directive {i}"))
+        assert c.carry == ["directive 0", "directive 1"]
+        assert c.dropped_carry == 3
+
+    def test_three_policies_in_one_pass_all_fit_by_default(self):
+        """The realistic case: cost_guard + tool_output_cap + progress_guard."""
+        c = ApplyControls()
+        c.apply(inject("BUDGET PRESSURE: keep responses minimal."))
+        c.apply(inject("NO PROGRESS DETECTED on 'search'."))
+        c.apply(mutate(inject_message="CONTEXT COMPACTED: older turns summarized."))
+        assert len(c.carry) == 3
+        assert c.dropped_carry == 0
+
+    def test_begin_call_resets_the_drop_counter(self):
+        c = ApplyControls(max_carry=1)
+        c.apply(inject("a"))
+        c.apply(inject("b"))
+        assert c.dropped_carry == 1
+        c.begin_call()
+        assert c.dropped_carry == 0
+
+    def test_tool_result_override_is_not_a_carry_message(self):
+        """A deep INJECT replaces the tool result; it must not spend carry budget."""
+        c = ApplyControls(max_carry=1)
+        c.apply(inject("OFFLOADED: handle=store://abc", replace_tool_result=True))
+        c.apply(inject("BUDGET PRESSURE: keep responses minimal."))
+        assert c.tool_result_override == "OFFLOADED: handle=store://abc"
+        assert c.carry == ["BUDGET PRESSURE: keep responses minimal."]
+        assert c.dropped_carry == 0
+
+
+def test_model_downgrade_and_cap_merge_together():
+    """The end-to-end shape of one observe pass with several policies firing."""
+    c = ApplyControls()
+    c.apply(inject("BUDGET PRESSURE: keep responses minimal."))
+    c.apply(mutate(downgrade_to="gpt-4o-mini", max_output_tokens=256))
+    c.apply(mutate(max_output_tokens=1024))
+    assert c.call.model_override == "gpt-4o-mini"
+    assert c.call.max_output_tokens == 256
+    assert c.carry == ["BUDGET PRESSURE: keep responses minimal."]
+    assert len(c.event_log) == 3
+
+
+@pytest.mark.parametrize("cap", [1, 16, 4096])
+def test_a_single_cap_is_always_honoured(cap):
+    c = ApplyControls()
+    c.apply(mutate(max_output_tokens=cap))
+    assert c.call.max_output_tokens == cap


### PR DESCRIPTION
From running all ten seeded policies one at a time and then testing what happens when several fire together. The policies are individually correct. The problems are between them.

`Governor._enforce` sorts signals by severity and then applies **every** one, so a single `observe` pass can hand `ApplyControls` actions from several policies. It overwrote rather than merged, and the winner was decided by severity rank then detector registration order, which no user controls or can see.

## Bug 1: a tighter output cap could be silently widened

`apply()` assigned `call.max_output_tokens` unconditionally. Reproduced:

| Step | Policy | Asked for |
|---|---|---|
| 1 | `cost_guard` tightening under budget pressure | **256** |
| 2 | `pre_call_worst_case` default cap | 1024 |
| | **resolved** | **1024** |

The tightening lost purely because of ordering. Caps now take the `min` of what any policy asked for, so they only ever tighten and the outcome no longer depends on order. Same probe now resolves to **256**.

## Bug 2: steer directives piled up without limit

Every INJECT appended to `carry`. With `cost_guard`, `tool_output_cap` and `progress_guard` firing together:

```
carry messages queued : 3
  1. BUDGET PRESSURE: keep responses minimal...
  2. TOOL OUTPUT OFFLOADED: ~8932 tokens, handle=store://abc...
  3. NO PROGRESS DETECTED on 'search': you are repeating...
```

`cost_guard` fires *because* spend is high, so the system's response to budget pressure was to add prompt tokens. `carry` now dedups and stops at `max_carry` (default 3), counting what it drops in `dropped_carry` for the dashboard. A deep INJECT that replaces a tool result does not spend carry budget, since it substitutes content rather than adding to it.

## Why merge rather than consolidate

The overlapping detectors (`tool_fix` vs `progress_guard`, `output_runaway` vs `progress_guard`'s llm path) stay. Merging them would be a breaking config change, and the overlap is harmless once ordering is deterministic. This fixes the two behaviours that were actually wrong without changing anyone's config.

## Verification

`tests/test_policy_coordination.py`, 14 tests, including that the resolved cap is identical whether the same four caps arrive in order or reversed.

**8 of those 14 fail on `main`**, so they catch the real behaviour rather than restating the new code.

- `ruff check` and `ruff format --check` clean
- `mypy` clean on 54 source files
- `pytest`: **217 passed, 3 skipped**, up from 203

## Not in this PR

Found in the same pass, worth separate issues: `context_compaction` ships `has_hook: false` so it is telemetry-only out of the box; `concurrency_cap`'s `queue` mode raises `Throttled` rather than queueing; `output_runaway` cannot do the CANCEL its docstring specifies (#67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)