### PR TITLE
docs(policies): point docs at docs/policies/ and document trajectory_hint exception (#68)

### DIFF
--- a/src/tokenops/control/policies/__init__.py
+++ b/src/tokenops/control/policies/__init__.py
@@ -3,7 +3,10 @@
 Every module exposes a ``build(...) -> tuple[Detector, Policy]`` factory so the config
 layer can instantiate templates declaratively and register them with the Governor.
 
-Governance docs (the action each policy takes) live in ``tokenops-lld/policies/``.
+Governance docs (the action each policy takes) live in ``docs/policies/``.
+
+Note: ``trajectory_hint`` requires a ``Store`` and is configured via
+``src/tokenops/control/config.py`` rather than exported here.
 """
 
 from tokenops.control.policies import (


### PR DESCRIPTION
﻿## Summary

Fixes #68 — updates `src/tokenops/control/policies/__init__.py` to point governance documentation to `docs/policies/` instead of non-existent `tokenops-lld/policies/`, and notes the `trajectory_hint` configuration exception.

## Changes

1. Corrected docstring path reference from ``tokenops-lld/policies/`` to ``docs/policies/``.
2. Documented why ``trajectory_hint`` is not exported alongside the other policy templates (requires a ``Store`` and is configured in ``src/tokenops/control/config.py``).

## Checklist
- [x] Corrected documentation link path
- [x] Documented trajectory_hint design exception
- [x] Staged as Draft PR
