### PR TITLE
ui: light, professional theme for the Admin/Dashboard/bench UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,8 +1,8 @@
 [theme]
-primaryColor = "#C9A227"
-backgroundColor = "#0A0A0A"
-secondaryBackgroundColor = "#121212"
-textColor = "#F0EDE4"
+primaryColor = "#A9762C"
+backgroundColor = "#FAFAF7"
+secondaryBackgroundColor = "#FFFFFF"
+textColor = "#1C1B17"
 font = "sans serif"
 
 [server]

--- a/src/tokenops/ui/theme.py
+++ b/src/tokenops/ui/theme.py
@@ -1,14 +1,16 @@
-"""Shared Streamlit styling — black + gold TokenOps look."""
+"""Shared Streamlit styling — light, minimalist TokenOps look."""
 
 from __future__ import annotations
 
 import streamlit as st
 
-GOLD = "#C9A227"
-GOLD_DIM = "#8A7020"
-INK = "#0A0A0A"
-PANEL = "#121212"
-MUTED = "#9A9588"
+GOLD = "#A9762C"
+GOLD_DIM = "#E3D3AE"
+INK = "#1C1B17"
+BG = "#FAFAF7"
+PANEL = "#FFFFFF"
+BORDER = "#E7E4DB"
+MUTED = "#716E63"
 
 
 def inject_theme() -> None:
@@ -16,25 +18,28 @@ def inject_theme() -> None:
         f"""
         <style>
         .stApp {{
-            background: linear-gradient(180deg, {INK} 0%, #0E0E0E 100%);
+            background: {BG};
         }}
         [data-testid="stSidebar"] {{
             background-color: {PANEL};
-            border-right: 1px solid #1F1F1F;
+            border-right: 1px solid {BORDER};
         }}
         [data-testid="stSidebar"] h1, [data-testid="stSidebar"] h2, [data-testid="stSidebar"] h3 {{
-            color: {GOLD};
+            color: {INK};
+        }}
+        [data-testid="stMarkdownContainer"] p, [data-testid="stMarkdownContainer"] li {{
+            color: {INK};
         }}
         .tokenops-header {{
             padding: 0.25rem 0 1.25rem 0;
-            border-bottom: 1px solid #222;
+            border-bottom: 1px solid {BORDER};
             margin-bottom: 1.25rem;
         }}
         .tokenops-title {{
             font-size: 1.75rem;
             font-weight: 700;
-            letter-spacing: 0.04em;
-            color: {GOLD};
+            letter-spacing: 0.02em;
+            color: {INK};
             margin: 0;
         }}
         .tokenops-sub {{
@@ -52,22 +57,23 @@ def inject_theme() -> None:
             text-transform: uppercase;
         }}
         .status-on {{
-            background: rgba(201, 162, 39, 0.15);
+            background: #F5EBD3;
             color: {GOLD};
             border: 1px solid {GOLD_DIM};
         }}
         .status-off {{
-            background: rgba(180, 60, 60, 0.12);
-            color: #E07070;
-            border: 1px solid #5A2020;
+            background: #FBEAEA;
+            color: #B23B3B;
+            border: 1px solid #EFC6C6;
         }}
         div[data-testid="stChatMessage"] {{
             background-color: {PANEL};
-            border: 1px solid #1E1E1E;
+            border: 1px solid {BORDER};
             border-radius: 12px;
+            box-shadow: 0 1px 2px rgba(28, 27, 23, 0.04);
         }}
         .stChatInput textarea {{
-            border-color: {GOLD_DIM} !important;
+            border-color: {BORDER} !important;
         }}
         .stChatInput textarea:focus {{
             border-color: {GOLD} !important;
@@ -75,39 +81,41 @@ def inject_theme() -> None:
         }}
         [data-testid="stMetric"] {{
             background: {PANEL};
-            border: 1px solid #1E1E1E;
+            border: 1px solid {BORDER};
             border-radius: 10px;
             padding: 0.65rem 0.85rem;
+            box-shadow: 0 1px 2px rgba(28, 27, 23, 0.04);
         }}
         [data-testid="stMetricLabel"] {{
             color: {MUTED} !important;
         }}
         [data-testid="stMetricValue"] {{
-            color: {GOLD} !important;
+            color: {INK} !important;
         }}
         .stTabs [data-baseweb="tab-list"] {{
             gap: 0.35rem;
-            border-bottom: 1px solid #222;
+            border-bottom: 1px solid {BORDER};
         }}
         .stTabs [data-baseweb="tab"] {{
-            background: {PANEL};
+            background: transparent;
             border-radius: 8px 8px 0 0;
             color: {MUTED};
             border: 1px solid transparent;
         }}
         .stTabs [aria-selected="true"] {{
             color: {GOLD} !important;
-            border-color: {GOLD_DIM} !important;
-            background: #181818 !important;
+            border-color: {BORDER} !important;
+            background: {PANEL} !important;
         }}
         [data-testid="stDataFrame"] {{
-            border: 1px solid #1E1E1E;
+            border: 1px solid {BORDER};
             border-radius: 8px;
         }}
         .stExpander {{
-            border: 1px solid #1E1E1E !important;
+            border: 1px solid {BORDER} !important;
             border-radius: 8px !important;
             background: {PANEL} !important;
+            box-shadow: 0 1px 2px rgba(28, 27, 23, 0.04);
         }}
         </style>
         """,

--- a/src/tokenops/ui/views/dashboard.py
+++ b/src/tokenops/ui/views/dashboard.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import altair as alt
 import pandas as pd
 import streamlit as st
 
 from tokenops.ui.run_detail import render_run_detail
 from tokenops.ui.store_client import get_store
-from tokenops.ui.theme import page_shell
+from tokenops.ui.theme import GOLD, MUTED, page_shell
 
 page_shell(subtitle="Run history, costs, and governance trace (read-only)")
 store = get_store()
@@ -116,7 +117,22 @@ with st.expander("Fleet overview", expanded=fleet_expanded):
         seg_runs[sv] = seg_runs.get(sv, 0) + 1
 
     st.subheader(f"Cost by {group_by}")
-    st.bar_chart(pd.DataFrame({"cost_usd": {s: _usd(m) for s, m in seg_cost.items()}}))
+    chart_df = pd.DataFrame(
+        [{group_by: s, "cost_usd": _usd(m)} for s, m in seg_cost.items()]
+    )
+    chart = (
+        alt.Chart(chart_df)
+        .mark_bar(color=GOLD, cornerRadiusTopLeft=3, cornerRadiusTopRight=3)
+        .encode(
+            x=alt.X(f"{group_by}:N", title=None, sort="-y"),
+            y=alt.Y("cost_usd:Q", title="Cost (USD)"),
+            tooltip=[group_by, "cost_usd"],
+        )
+        .configure_axis(labelColor=MUTED, titleColor=MUTED, domainColor="#E7E4DB", gridColor="#F0EEE7")
+        .configure_view(strokeWidth=0)
+        .properties(height=260)
+    )
+    st.altair_chart(chart, use_container_width=True)
     st.dataframe(
         pd.DataFrame(
             [


### PR DESCRIPTION
## Summary

- Switch the product UI (`src/tokenops/ui/`) and bench UI (`examples/ui/`, both share `tokenops.ui.theme`) from the black+gold dark theme to a light, minimalist palette: warm-white page background, white cards with a subtle border/shadow, near-black text, and a muted bronze-gold accent kept only for emphasis (status pills, active tab, the Cost-by-agent chart).
- Updated both `src/tokenops/ui/theme.py` (custom CSS) and `.streamlit/config.toml` (Streamlit's own `[theme]` block, which drives native widget colors the custom CSS doesn't touch — buttons, inputs, selects).
- Fixed the Dashboard's "Cost by X" chart (`src/tokenops/ui/views/dashboard.py`): it was `st.bar_chart`, which draws no axis labels and picks colors from Streamlit's default categorical palette (not the app's theme). A single-segment run — the common case — rendered as an unlabeled solid colored block. Replaced with an Altair chart using the theme's accent color and explicit x/y encoding, so the segment name and cost axis are always visible regardless of how many segments there are.

## Why

The README's hero demo gif shows this UI, and the dark theme's dashboard chart is one of the two things flagged as needing work (the other, a `ButtonMixin.page_link()` crash visible in the recorded gif, was investigated separately — see notes below, no code change needed for it).

## Investigated separately: the TypeError in the current hero gif

The existing recorded gif briefly shows `TypeError: ButtonMixin.page_link() got an unexpected keyword argument 'query_params'`. I set up a fresh `pip install -e .` (pulls Streamlit 1.63.0, today's latest) and exercised the two most likely trigger paths — sidebar navigation clicks and a direct `?run_id=` deep link — neither reproduces the crash. TokenOps' own code never calls `page_link` (confirmed via search across `src/`), so this was Streamlit's own internal `st.navigation` → `page_link` wiring hitting a version-specific regression at the time the gif was recorded, since fixed upstream. A fresh install today does not hit it.

## Screenshots

Verified locally against seeded demo data (`examples/ui/simulator.py` in demo mode, no API keys) on Streamlit 1.63.0: header, metric cards, and the Cost-by-agent chart all render cleanly in the new palette, and the chart now shows a labeled axis and theme-matching bronze-gold bar instead of an unlabeled blue block.

## Test plan

- [x] Installed the package fresh, ran `streamlit run examples/ui/app.py`, confirmed sidebar/header/cards/chat render in the new light theme with no console errors
- [x] Seeded demo runs via the in-process simulator (no API key needed) and confirmed the Dashboard's metrics and Cost-by-agent chart render correctly, themed, and labeled
- [x] Confirmed the previously-seen `page_link` TypeError does not reproduce on a fresh install
- [ ] Re-record `examples/demo-assets/videos/02_governance_on_budget_cap.webm`/`.gif` against this theme for the README hero (tracked as follow-up — needs the full two-agent bench + Playwright capture + ffmpeg gif conversion, a separate pass from this UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)