### PR TITLE
docs: land the remaining badge/hero README follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # TokenOps
 
-**Cuts wasted agent spend before it happens, not after the bill arrives.**<br>
-One budget for the whole run, checked before every call.
+**Cuts wasted agent spend by checking the run's budget before every call.**
 
 [![CI](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-tokenops.svg)](https://pypi.org/project/agent-tokenops/)
@@ -13,9 +12,9 @@ One budget for the whole run, checked before every call.
 [![GitHub stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=social)](https://github.com/theagentplane/tokenops/stargazers)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-The%20Agent%20Plane-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)
 
-[![Featured by Microsoft Developer](https://img.shields.io/badge/press-Microsoft%20Developer-6a737d)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
-[![Featured by Command Line](https://img.shields.io/badge/press-Command%20Line-6a737d)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
-[![Featured by AI Engineer World's Fair](https://img.shields.io/badge/press-AI%20Engineer%20World's%20Fair-6a737d)](https://www.youtube.com/watch?v=GJX19pNhmSw)
+[![Featured by Microsoft Developer](https://img.shields.io/badge/press-Microsoft%20Developer-lightgrey)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
+[![Featured by Command Line](https://img.shields.io/badge/press-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
+[![Featured by AI Engineer World's Fair](https://img.shields.io/badge/press-AI%20Engineer%20World's%20Fair-lightgrey)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 [![GitHub stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=social)](https://github.com/theagentplane/tokenops/stargazers)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)
-[![GitHub Discussions](https://img.shields.io/github/discussions/theagentplane/tokenops)](https://github.com/theagentplane/tokenops/discussions)
+[![GitHub Discussions](https://img.shields.io/badge/Discussions-24292f?logo=github&logoColor=white)](https://github.com/theagentplane/tokenops/discussions)
 
 [![Featured by Microsoft Developer](https://img.shields.io/badge/press-Microsoft%20Developer-lightgrey)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
 [![Featured by Command Line](https://img.shields.io/badge/press-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![Downloads](https://img.shields.io/pepy/dt/agent-tokenops)](https://pepy.tech/project/agent-tokenops)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 [![GitHub stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=social)](https://github.com/theagentplane/tokenops/stargazers)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-The%20Agent%20Plane-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)
+[![GitHub Discussions](https://img.shields.io/github/discussions/theagentplane/tokenops)](https://github.com/theagentplane/tokenops/discussions)
 
 [![Featured by Microsoft Developer](https://img.shields.io/badge/press-Microsoft%20Developer-lightgrey)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
 [![Featured by Command Line](https://img.shields.io/badge/press-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
@@ -16,7 +17,7 @@
 
 <br>
 
-Built by <b><a href="https://www.linkedin.com/in/susheemkoul/">Susheem Koul</a></b> and <b><a href="https://www.linkedin.com/in/tisha-chawla/">Tisha Chawla</a></b>
+<sub>Built by <b><a href="https://www.linkedin.com/in/susheemkoul/">Susheem Koul</a></b> and <b><a href="https://www.linkedin.com/in/tisha-chawla/">Tisha Chawla</a></b></sub>
 
 <a href="https://github.com/theagentplane/tokenops/raw/main/examples/demo-assets/videos/02_governance_on_budget_cap.webm">
 <img src="https://raw.githubusercontent.com/theagentplane/tokenops/main/examples/demo-assets/videos/02_governance_on_budget_cap.gif" alt="TokenOps demo: a governed Research to Summarize run halts when worst-case cost exceeds the remaining run budget, then the Dashboard shows spend and governance per agent" width="720" />

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 
 **Cuts wasted agent spend by checking the run's budget before every call.**
 
-[![CI](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml/badge.svg)](https://github.com/theagentplane/tokenops/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/agent-tokenops.svg)](https://pypi.org/project/agent-tokenops/)
 [![Downloads](https://img.shields.io/pepy/dt/agent-tokenops)](https://pepy.tech/project/agent-tokenops)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://pypi.org/project/agent-tokenops/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 [![GitHub stars](https://img.shields.io/github/stars/theagentplane/tokenops?style=social)](https://github.com/theagentplane/tokenops/stargazers)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-The%20Agent%20Plane-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)


### PR DESCRIPTION
## Summary

PR #75 merged partway through iterating on the badges, so these four follow-up commits never landed on \`main\`. Rebased cleanly onto current \`main\` (no conflicts):

- Single-line hero tagline: "Cuts wasted agent spend by checking the run's budget before every call."
- Press badges lightened from a dark slate (\`6a737d\`) to \`lightgrey\`, per feedback that the dark ones were hard to read
- Dropped the CI and Python-version badges from the hero row
- LinkedIn badge trimmed to just the logo (no "The Agent Plane" text); added a GitHub Discussions badge right after it (static "Discussions" label, no live count — a live \`shields.io/github/discussions\` badge showed a distracting "1 total")
- "Built by ..." byline wrapped in \`<sub>\` for a smaller, secondary look

## Test plan

- [x] Rebased onto current \`main\`, no conflicts
- [x] Diffed the resulting README.md hero section against what was verified live on the branch before rebase — matches
- [ ] Confirm badges render as expected once merged (same shields.io URLs already verified working on the original branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)