### PR TITLE
docs: land the second round of README follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <br>
 
-[Core features](#-core-features) · [Quickstart](#-quickstart) · [Quickdeploy](#-quickdeploy) · [How it compares](#how-tokenops-compares) · [See it work](#see-it-work) · [Policies](docs/policies/) · [Upcoming features](#upcoming-features) · [Support](#support) · [Contributing](#contributing)
+[Core features](#-core-features) · [Quickstart](#-quickstart) · [Quickdeploy](#-quickdeploy) · [How it compares](#how-tokenops-compares) · [See it work](#see-it-work) · [Policies](docs/policies/) · [Support](#support) · [Contributing](#contributing)
 
 </div>
 
@@ -110,7 +110,7 @@ run is out, even from another process.
 | One budget across several agent processes | [Shared plane](.claude/skills/integrate-tokenops/SKILL.md#tier-2--several-processes-one-budget) |
 | FastAPI or A2A services | [Instrumented app](.claude/skills/integrate-tokenops/SKILL.md#tier-3--fastapi--a2a) |
 | Something other than stopping | [The ten policies](docs/policies/) |
-| Cost per agent in a dashboard | [Run it locally](#run-it-locally) |
+| Cost per agent in a dashboard | [Quickdeploy](#-quickdeploy) |
 | A worked end-to-end example | [Field guide](docs/guides/field-guide-add-tokenops.md) |
 | Everything else | [Onboarding guide](docs/guides/onboarding.md) |
 
@@ -130,6 +130,60 @@ docker compose --profile ui up --build
 
 Plane: `localhost:7700/health` · Dashboard: `localhost:8501`. Plane only:
 `docker compose up --build`. Details: [`docs/control-plane-deploy.md`](docs/control-plane-deploy.md).
+
+<details>
+<summary><b>Without Docker</b> (make)</summary>
+
+<br>
+
+```bash
+git clone https://github.com/theagentplane/tokenops && cd tokenops
+make install
+make run          # control plane :7700 + Admin/Dashboard :8501
+```
+
+Then open `localhost:8501` to see spend and governance per agent.
+
+</details>
+
+<details>
+<summary><b>Multi-agent benches</b>: watch one budget span several agents</summary>
+
+<br>
+
+Each is a real multi-agent stack sharing one run ledger. One target starts the
+plane, the agents, and the Admin UI.
+
+| Bench | Agents | Run |
+|---|---|---|
+| Two-agent | Research to Summarize | `make demo` |
+| Triad | Planner to Researcher to Writer | `make demo-triad` |
+| Brief | Scout to Analyst to Editor (LangChain) | `make demo-brief` |
+| Bench UI | Chat + Simulator only | `make bench-ui` |
+
+`cp .env.example .env` first if you want them to call real models. See
+[`examples/README.md`](examples/README.md) for the bench profiles.
+
+</details>
+
+<details>
+<summary><b>Pointing several processes at one plane</b></summary>
+
+<br>
+
+```bash
+export TOKENOPS_URL=http://localhost:7700
+export TOKENOPS_DB=tokenops.db   # plane and every agent read the same file
+```
+
+> `TOKENOPS_EMBEDDED=1` overrides `TOKENOPS_URL`. Leave it unset here, or each
+> process silently falls back to its own local ledger and gets the full budget.
+
+PyPI name is `agent-tokenops`; the import is `tokenops`. Extras:
+`pip install "agent-tokenops[examples]"` for the LangChain benches,
+`".[dev,examples]"` from source. Releases: [`RELEASING.md`](RELEASING.md).
+
+</details>
 
 ## How TokenOps compares
 
@@ -169,60 +223,6 @@ An agent makes 40 model calls. Budget for the whole run: $2.00.
 
 $2.03 vs $5.80, about 65% less. No single call was expensive; the 40 together
 crossed the cap, which a per-request limit can't see.
-
-## Run it locally
-
-For the same result without Docker, or to run the multi-agent benches. The
-demo above needs none of this.
-
-```bash
-git clone https://github.com/theagentplane/tokenops && cd tokenops
-make install
-make run          # control plane :7700 + Admin/Dashboard :8501
-```
-
-Then open `localhost:8501` to see spend and governance per agent.
-
-<details>
-<summary><b>Multi-agent benches</b>: watch one budget span several agents</summary>
-
-<br>
-
-Each is a real multi-agent stack sharing one run ledger. One target starts the
-plane, the agents, and the Admin UI.
-
-| Bench | Agents | Run |
-|---|---|---|
-| Two-agent | Research to Summarize | `make demo` |
-| Triad | Planner to Researcher to Writer | `make demo-triad` |
-| Brief | Scout to Analyst to Editor (LangChain) | `make demo-brief` |
-| Bench UI | Chat + Simulator only | `make bench-ui` |
-
-`cp .env.example .env` first if you want them to call real models.
-
-For Docker instead of make, see [Quickdeploy](#-quickdeploy) above and
-[`examples/README.md`](examples/README.md) for the bench profiles.
-
-</details>
-
-<details>
-<summary><b>Pointing several processes at one plane</b></summary>
-
-<br>
-
-```bash
-export TOKENOPS_URL=http://localhost:7700
-export TOKENOPS_DB=tokenops.db   # plane and every agent read the same file
-```
-
-> `TOKENOPS_EMBEDDED=1` overrides `TOKENOPS_URL`. Leave it unset here, or each
-> process silently falls back to its own local ledger and gets the full budget.
-
-PyPI name is `agent-tokenops`; the import is `tokenops`. Extras:
-`pip install "agent-tokenops[examples]"` for the LangChain benches,
-`".[dev,examples]"` from source. Releases: [`RELEASING.md`](RELEASING.md).
-
-</details>
 
 ## Reference
 
@@ -334,23 +334,12 @@ tests/                     # unit + e2e
 
 </details>
 
-## Upcoming features
-
-TokenOps is early (0.x). Near-term:
-
-- User/tag segment-scoped budgets (machinery exists; seed is run-only today).
-- Optional fail-closed integrity: refuse on missing registration or exceeded budget.
-- Remote observe / decide (fatter plane) for multi-host stacks.
-- Documentation site.
-
-Status of each control-plane job: [`docs/control-plane-status.md`](docs/control-plane-status.md).
-
 ## 📰 Talks & press
 
 - **Featured by Microsoft Developer**: “Who spent all the tokens?” on
   [LinkedIn](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b) and [X](https://x.com/msdev/status/2093425027500978292).
-- **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)**: *Command Line*, a Microsoft publication. Why per-request caps miss agent workflows, and how a run-scoped ledger plus in-path enforcement stops the bill mid-run.
-- **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)**: talk at the **AI Engineer World's Fair**, San Francisco. Live walkthrough of a governed multi-agent run hitting its budget cap.
+- **[Who spent all the tokens? Real-time, run-scoped cost control for AI agents](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)**: *Command Line*, a Microsoft publication.
+- **[FinOps for AI Agents: Who Spent All the Tokens?](https://www.youtube.com/watch?v=GJX19pNhmSw)**: talk at the **AI Engineer World's Fair**, San Francisco.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/the-agent-plane/)
 [![GitHub Discussions](https://img.shields.io/badge/Discussions-24292f?logo=github&logoColor=white)](https://github.com/theagentplane/tokenops/discussions)
 
-[![Featured by Microsoft Developer](https://img.shields.io/badge/press-Microsoft%20Developer-lightgrey)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
-[![Featured by Command Line](https://img.shields.io/badge/press-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
-[![Featured by AI Engineer World's Fair](https://img.shields.io/badge/press-AI%20Engineer%20World's%20Fair-lightgrey)](https://www.youtube.com/watch?v=GJX19pNhmSw)
+[![Featured by Microsoft Developer](https://img.shields.io/badge/Featured-Microsoft%20Developer-lightgrey)](https://www.linkedin.com/posts/microsoft-developers_who-spent-all-the-tokens-tokenops-gives-activity-7499191980715982848-224b)
+[![Featured by Command Line](https://img.shields.io/badge/Featured-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
+[![Featured by AI Engineer World's Fair](https://img.shields.io/badge/Featured-AI%20Engineer%20World's%20Fair-lightgrey)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,14 @@
 
 ## ✨ Core features
 
-An agent workflow can call a model twenty times. Each call passes its own limit,
-but the workflow still costs ten times what was expected, because nothing was
-counting it as one thing. TokenOps gives the whole workflow one budget, checked
-before each call instead of reported after.
+Per-call limits miss the workflow as a whole, so a chain of individually-cheap
+calls can quietly cost far more than expected. TokenOps gives the whole run one
+budget, checked before every call instead of reported after the fact.
 
 <img src="docs/assets/core-features.svg" alt="TokenOps core features: enforced pre-call, run-scoped budget, shared across processes, steers not just stops, tool calls count too, ten policies included" width="100%" />
 
-Ten policies ship configured in [`docs/policies/`](docs/policies/); add your own
-with the same `(Detector, Policy)` shape.
+Ten policies ship configured in [`docs/policies/`](docs/policies/), and you can
+add your own.
 
 ## 🚀 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@
 
 ## ✨ Core features
 
-Per-call limits miss the workflow as a whole, so a chain of individually-cheap
-calls can quietly cost far more than expected. TokenOps gives the whole run one
-budget, checked before every call instead of reported after the fact.
+A per-request limit only looks at one call at a time, so a string of cheap
+calls can quietly add up to far more than you expected. TokenOps tracks the
+whole run against one budget, and checks it before every call, not after.
 
 <img src="docs/assets/core-features.svg" alt="TokenOps core features: enforced pre-call, run-scoped budget, shared across processes, steers not just stops, tool calls count too, ten policies included" width="100%" />
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 [![Featured by Command Line](https://img.shields.io/badge/Featured-Command%20Line-lightgrey)](https://commandline.microsoft.com/tokenops-real-time-run-scoped-cost-control-ai-agents/)
 [![Featured by AI Engineer World's Fair](https://img.shields.io/badge/Featured-AI%20Engineer%20World's%20Fair-lightgrey)](https://www.youtube.com/watch?v=GJX19pNhmSw)
 
-<br>
-
 <sub>Built by <b><a href="https://www.linkedin.com/in/susheemkoul/">Susheem Koul</a></b> and <b><a href="https://www.linkedin.com/in/tisha-chawla/">Tisha Chawla</a></b></sub>
 
 <a href="https://github.com/theagentplane/tokenops/raw/main/examples/demo-assets/videos/02_governance_on_budget_cap.webm">
@@ -25,13 +23,11 @@
 
 <sub><i>Governed Research → Summarize run: the budget cap halts spend mid-run, then the Dashboard attributes cost per agent. <a href="https://github.com/theagentplane/tokenops/raw/main/examples/demo-assets/videos/02_governance_on_budget_cap.webm">Full video</a>.</i></sub>
 
-<br><br>
+<br>
 
-[Core features](#-core-features) · [Quickstart](#-quickstart) · [See it work](#see-it-work) · [Quickdeploy](#quickdeploy) · [How it compares](#how-tokenops-compares) · [Policies](docs/policies/) · [Upcoming features](#upcoming-features) · [Support](#support) · [Contributing](#contributing)
+[Core features](#-core-features) · [Quickstart](#-quickstart) · [Quickdeploy](#-quickdeploy) · [How it compares](#how-tokenops-compares) · [See it work](#see-it-work) · [Policies](docs/policies/) · [Upcoming features](#upcoming-features) · [Support](#support) · [Contributing](#contributing)
 
 </div>
-
-<br>
 
 > ### 🙌 Open to contribution
 >
@@ -39,8 +35,6 @@
 > we are growing the community working on that. Policies, actuators, and the
 > shared ledger are all open to extension. See
 > **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started.
-
-<br>
 
 ## ✨ Core features
 
@@ -120,6 +114,23 @@ run is out, even from another process.
 | A worked end-to-end example | [Field guide](docs/guides/field-guide-add-tokenops.md) |
 | Everything else | [Onboarding guide](docs/guides/onboarding.md) |
 
+## 🐳 Quickdeploy
+
+> [!TIP]
+> The control plane (`python -m tokenops.server`) shares one budget across
+> processes and powers the dashboard. A single-process agent doesn't need it
+> running at all.
+
+One command, plane + dashboard:
+
+```bash
+git clone https://github.com/theagentplane/tokenops && cd tokenops
+docker compose --profile ui up --build
+```
+
+Plane: `localhost:7700/health` · Dashboard: `localhost:8501`. Plane only:
+`docker compose up --build`. Details: [`docs/control-plane-deploy.md`](docs/control-plane-deploy.md).
+
 ## How TokenOps compares
 
 TokenOps is not a gateway or a tracing dashboard. It governs the **run**, a full agent workflow, and sits alongside the tools you already use for routing and observability.
@@ -136,42 +147,16 @@ What this does **not** do: replace your LLM gateway, replace Chronicle-style rec
 
 Longer table with logos: [`docs/product/comparison.md`](docs/product/comparison.md).
 
-## Quickdeploy
-
-> [!TIP]
-> The **control plane** is the small service (`python -m tokenops.server`) that
-> stores each run's budget and ledger in one shared SQLite file, so several agent
-> processes can check the same running total. A single-process agent does not
-> need it running at all; TokenOps just opens a local ledger file for itself.
-> Stand up the control plane once you want a budget shared across processes,
-> or the dashboard.
-
-One Docker command brings up the control plane and the Admin/Dashboard together,
-no local Python setup:
-
-```bash
-git clone https://github.com/theagentplane/tokenops && cd tokenops
-docker compose --profile ui up --build
-```
-
-Plane health check: `localhost:7700/health` · Dashboard: `localhost:8501`.
-
-Plane only, no UI: `docker compose up --build`. Service breakdown, env vars, and
-running the example agents over Docker:
-[`docs/control-plane-deploy.md`](docs/control-plane-deploy.md).
-
 ## See it work
 
-Want to see the mechanism before touching your own code? This needs no install
-beyond the package, no API keys, no server, no Docker:
+No install beyond the package, no API keys, no server:
 
 ```bash
 pip install agent-tokenops
 python -m tokenops.demo
 ```
 
-This runs the same 40-call agent loop twice, once ungoverned and once with
-TokenOps watching the run:
+Same 40-call agent loop, governed and not:
 
 ```
 An agent makes 40 model calls. Budget for the whole run: $2.00.
@@ -182,9 +167,8 @@ An agent makes 40 model calls. Budget for the whole run: $2.00.
   $3.77 not spent. The run stopped itself.
 ```
 
-No single call in that run was expensive. It was the 40 of them together that
-crossed the cap, $2.03 against $5.80, about 65% less, which is exactly what a
-per-request limit cannot see because it only ever looks at one call at a time.
+$2.03 vs $5.80, about 65% less. No single call was expensive; the 40 together
+crossed the cap, which a per-request limit can't see.
 
 ## Run it locally
 
@@ -216,7 +200,7 @@ plane, the agents, and the Admin UI.
 
 `cp .env.example .env` first if you want them to call real models.
 
-For Docker instead of make, see [Quickdeploy](#quickdeploy) above and
+For Docker instead of make, see [Quickdeploy](#-quickdeploy) above and
 [`examples/README.md`](examples/README.md) for the bench profiles.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@
 
 ## ✨ Core features
 
-A per-request limit only looks at one call at a time, so a string of cheap
-calls can quietly add up to far more than you expected. TokenOps tracks the
-whole run against one budget, and checks it before every call, not after.
+A per-request limit only looks at one call at a time, so a lot of cheap calls
+can quietly add up to far more than you expected. TokenOps tracks the whole
+run against one budget, and checks it before every call, not after.
 
 <img src="docs/assets/core-features.svg" alt="TokenOps core features: enforced pre-call, run-scoped budget, shared across processes, steers not just stops, tool calls count too, ten policies included" width="100%" />
 
@@ -55,16 +55,14 @@ add your own.
 
 ## 🚀 Quickstart
 
-Wire TokenOps into your own agent, then look up anything more specific you need.
-Requires Python 3.10+. Want to see it work first, with nothing installed but the
-package? Jump to [See it work](#see-it-work).
+Requires Python 3.10+. Want to see it run first, before touching your own code?
+Jump to [See it work](#see-it-work).
 
 ### 1. Put it in your agent
 
-**The fastest way is to let your coding assistant do it.** TokenOps ships an
-integration skill: a written procedure your assistant reads and follows so you
-do not have to. It reads your agent's code, picks the right setup for it, wires
-in the one enforcement point, and tells you what to check afterward.
+**Skill (recommended).** Your coding assistant reads
+[`SKILL.md`](.claude/skills/integrate-tokenops/SKILL.md), wires the one
+enforcement point into your agent, and tells you what to check.
 
 In **Claude Code**, from a clone:
 
@@ -72,18 +70,13 @@ In **Claude Code**, from a clone:
 /integrate-tokenops
 ```
 
-In **Cursor, Copilot, or anywhere else**, paste this:
+Anywhere else (Cursor, Copilot, ...), paste this:
 
 > Integrate TokenOps into this agent, following
 > https://github.com/theagentplane/tokenops/blob/main/.claude/skills/integrate-tokenops/SKILL.md
 
-The skill handles three setups: one process, several processes sharing one budget,
-or FastAPI and A2A services. It is
-[`.claude/skills/integrate-tokenops/SKILL.md`](.claude/skills/integrate-tokenops/SKILL.md),
-plain markdown, readable on its own if you would rather follow it yourself.
-
 <details>
-<summary><b>Or wire it yourself</b>, about ten lines</summary>
+<summary><b>Manual</b>, about ten lines</summary>
 
 <br>
 
@@ -109,12 +102,9 @@ with tokenops_run(client=client, service="my-agent", intent="research",
         print(f"run stopped: {stopped}")
 ```
 
-**The only change to your agent is that one line.** If your agent hard-codes its
-model client, make the completion function injectable. Nothing else moves.
-
-`wrap_complete` checks the budget before each call and records the cost after.
-When the run runs out, it raises `Halt`, and later calls on that run are refused,
-even from another process.
+Pass `governed` to your agent instead of `complete`; nothing else changes.
+`wrap_complete` checks the budget before each call and raises `Halt` when the
+run is out, even from another process.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@
 
 <br>
 
+> ### 🙌 Open to contribution
+>
+> Token spend deserves the same first-class attention as compute or latency, and
+> we are growing the community working on that. Policies, actuators, and the
+> shared ledger are all open to extension. See
+> **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started.
+
+<br>
+
 ## ✨ Core features
 
 An agent workflow can call a model twenty times. Each call passes its own limit,

--- a/docs/assets/core-features.svg
+++ b/docs/assets/core-features.svg
@@ -94,8 +94,8 @@
     <circle cx="23" cy="22" r="2.2" fill="#f6d34a"/>
     <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">EXTENSIBLE</text>
     <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Ten policies included</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Each documented and swappable.</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">Add your own with the same</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">(Detector, Policy) shape.</text>
+    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Each documented and swappable,</text>
+    <text x="0" y="122" font-size="12.5" fill="#5c5c54">covering the common ways a run</text>
+    <text x="0" y="140" font-size="12.5" fill="#5c5c54">goes wrong. Add your own too.</text>
   </g>
 </svg>

--- a/docs/assets/core-features.svg
+++ b/docs/assets/core-features.svg
@@ -78,10 +78,10 @@
     <line x1="10" y1="13" x2="20" y2="13" stroke="#f6d34a" stroke-width="1.6"/>
     <line x1="10" y1="17" x2="17" y2="17" stroke="#f6d34a" stroke-width="1.6"/>
     <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">SPEND</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Tool calls count too</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Not just model calls. Search</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">results and file reads that land</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">in the next prompt are real spend.</text>
+    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Nothing hides in a tool call</text>
+    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Search results and file reads</text>
+    <text x="0" y="122" font-size="12.5" fill="#5c5c54">that land in the next prompt are</text>
+    <text x="0" y="140" font-size="12.5" fill="#5c5c54">real spend, and get counted.</text>
   </g>
 
   <!-- Card 6 -->
@@ -92,10 +92,10 @@
     <circle cx="23" cy="8" r="2.2" fill="#f6d34a"/>
     <circle cx="7" cy="22" r="2.2" fill="#f6d34a"/>
     <circle cx="23" cy="22" r="2.2" fill="#f6d34a"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">EXTENSIBLE</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Ten policies included</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Each documented and swappable,</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">covering the common ways a run</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">goes wrong. Add your own too.</text>
+    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">BATTERIES INCLUDED</text>
+    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Governance, out of the box</text>
+    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Ten documented policies covering</text>
+    <text x="0" y="122" font-size="12.5" fill="#5c5c54">the common ways a run goes</text>
+    <text x="0" y="140" font-size="12.5" fill="#5c5c54">wrong. Add your own alongside.</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

PR #78 merged partway through this round of edits too, so 9 commits never landed on `main`. Rebased cleanly (no conflicts):

- "Featured" badge label, "Open to contribution" callout before Core features, Detector/Policy jargon dropped (prose + graphic), two weak card titles sharpened ("Tool calls count too" → "Nothing hides in a tool call", "Ten policies included" → "Governance, out of the box")
- Core features intro rephrased in plainer language, and fixed an awkward "string of cheap calls" phrase
- Quickstart tightened: cut redundant prose around the integration skill, trimmed the manual-wiring explanation
- Quickdeploy moved earlier (right after Quickstart, before the comparison table), given a 🐳, and its copy cut to one idea per line
- **Run it locally folded into Quickdeploy** as a "Without Docker" details block, alongside the existing bench/multi-process details — it was duplicating Quickdeploy's job as a second top-level "get it running" section
- **Upcoming features section removed** (roadmap belongs in issues/milestones)
- Talks & press trimmed to just the pointer, dropping the descriptive sentences
- Three redundant `<br>` spacers cut from the hero

## Test plan

- [x] Rebased onto current `main`, no conflicts
- [x] Grepped for the removed sections/anchors (`Upcoming features`, `Run it locally`, old `#quickdeploy` anchor) to confirm no dangling references
- [ ] Spot-check the rendered README once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)