### PR TITLE
docs: final README polish pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <br>
 
-[Core features](#-core-features) · [Quickstart](#-quickstart) · [Quickdeploy](#-quickdeploy) · [How it compares](#how-tokenops-compares) · [See it work](#see-it-work) · [Policies](docs/policies/) · [Support](#support) · [Contributing](#contributing)
+[Core features](#-core-features) · [Quickstart](#-quickstart) · [Quickdeploy](#-quickdeploy) · [How it compares](#how-tokenops-compares) · [See it work](#see-it-work) · [Policies](docs/policies/) · [Support](#support) · [Contributing](#-open-to-contribution)
 
 </div>
 
@@ -38,11 +38,11 @@
 
 ## ✨ Core features
 
-A per-request limit only looks at one call at a time, so a lot of cheap calls
-can quietly add up to far more than you expected. TokenOps tracks the whole
-run against one budget, and checks it before every call, not after.
+Cheap calls add up fast, and a per-request limit never sees it coming, since
+it only ever checks one call at a time. TokenOps watches the whole run
+instead: one budget, checked before every call, not after.
 
-<img src="docs/assets/core-features.svg" alt="TokenOps core features: enforced pre-call, run-scoped budget, shared across processes, steers not just stops, tool calls count too, ten policies included" width="100%" />
+<img src="docs/assets/core-features.svg" alt="TokenOps core features: enforced pre-call, run-scoped budget, shared across processes, steers not just stops, tool calls count too, ten policies included" width="850" />
 
 Ten policies ship configured in [`docs/policies/`](docs/policies/), and you can
 add your own.
@@ -71,8 +71,6 @@ Anywhere else (Cursor, Copilot, ...), paste this:
 
 <details>
 <summary><b>Manual</b>, about ten lines</summary>
-
-<br>
 
 Wrap your model call once, then hand the wrapped version to your agent.
 
@@ -134,8 +132,6 @@ Plane: `localhost:7700/health` · Dashboard: `localhost:8501`. Plane only:
 <details>
 <summary><b>Without Docker</b> (make)</summary>
 
-<br>
-
 ```bash
 git clone https://github.com/theagentplane/tokenops && cd tokenops
 make install
@@ -148,8 +144,6 @@ Then open `localhost:8501` to see spend and governance per agent.
 
 <details>
 <summary><b>Multi-agent benches</b>: watch one budget span several agents</summary>
-
-<br>
 
 Each is a real multi-agent stack sharing one run ledger. One target starts the
 plane, the agents, and the Admin UI.
@@ -168,8 +162,6 @@ plane, the agents, and the Admin UI.
 
 <details>
 <summary><b>Pointing several processes at one plane</b></summary>
-
-<br>
 
 ```bash
 export TOKENOPS_URL=http://localhost:7700
@@ -203,14 +195,12 @@ Longer table with logos: [`docs/product/comparison.md`](docs/product/comparison.
 
 ## See it work
 
-No install beyond the package, no API keys, no server:
+No install, no API keys, no server:
 
 ```bash
 pip install agent-tokenops
 python -m tokenops.demo
 ```
-
-Same 40-call agent loop, governed and not:
 
 ```
 An agent makes 40 model calls. Budget for the whole run: $2.00.
@@ -220,9 +210,6 @@ An agent makes 40 model calls. Budget for the whole run: $2.00.
 
   $3.77 not spent. The run stopped itself.
 ```
-
-$2.03 vs $5.80, about 65% less. No single call was expensive; the 40 together
-crossed the cap, which a per-request limit can't see.
 
 ## Reference
 
@@ -359,28 +346,6 @@ through, [book a slot](https://calendly.com/theagentplane/theagentplane).
 **Writing, talks and videos** from the people building this, on agent
 observability, replay testing, and token infrastructure:
 **[theagentplane.github.io/media](https://theagentplane.github.io/media.html)**.
-
-## Contributing
-
-Good first contributions are labelled
-[`good first issue`](https://github.com/theagentplane/tokenops/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-and [`help wanted`](https://github.com/theagentplane/tokenops/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
-Two areas take contributions without touching the core:
-
-- **A new policy** (a detector plus a decision) under `src/tokenops/control/policies/`.
-  Ten existing ones are working references, one doc each in [`docs/policies/`](docs/policies/).
-- **A new adapter** so another SDK can be governed, under `src/tokenops/adapters/`.
-
-Open an issue before a pull request so the approach can be agreed there first;
-typos and small docs fixes can go straight to a PR. See
-[CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md),
-and [SECURITY.md](SECURITY.md).
-
-```bash
-make install
-make lint
-make test
-```
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -330,22 +330,14 @@ tests/                     # unit + e2e
 
 ## Support
 
-Found a bug? [Open an issue](https://github.com/theagentplane/tokenops/issues)
-with expected vs actual behavior and a minimal repro. For a security issue, see
-[SECURITY.md](SECURITY.md) instead of filing a public issue.
-
-**[Join The Agent Plane on Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg)**
-for real-time questions, integration help, and demos of what you have governed.
-
-For longer-form questions, ideas, and show-and-tell, use
-[GitHub Discussions](https://github.com/theagentplane/tokenops/discussions).
-
-**Office hours:** if you are wiring TokenOps into a real stack and want to talk it
-through, [book a slot](https://calendly.com/theagentplane/theagentplane).
-
-**Writing, talks and videos** from the people building this, on agent
-observability, replay testing, and token infrastructure:
-**[theagentplane.github.io/media](https://theagentplane.github.io/media.html)**.
+| Need | Where |
+|---|---|
+| Report a bug | [Open an issue](https://github.com/theagentplane/tokenops/issues) with expected vs actual behavior and a minimal repro |
+| Report a security issue | [SECURITY.md](SECURITY.md), not a public issue |
+| Real-time questions, integration help | [Slack](https://join.slack.com/t/theagentplane/shared_invite/zt-47lqx2xtc-0idr1cuLNJ_JDTgqxDiUsg) |
+| Longer-form questions, ideas, show-and-tell | [GitHub Discussions](https://github.com/theagentplane/tokenops/discussions) |
+| Talk through a real integration | [Book office hours](https://calendly.com/theagentplane/theagentplane) |
+| Talks, writing, videos | [theagentplane.github.io/media](https://theagentplane.github.io/media.html) |
 
 ## Contributors
 

--- a/docs/assets/core-features.svg
+++ b/docs/assets/core-features.svg
@@ -1,19 +1,25 @@
 <svg width="1200" height="560" viewBox="0 0 1200 560" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
-  <rect x="0" y="0" width="1200" height="560" rx="20" fill="#f6f6f4"/>
-  <rect x="20" y="20" width="1160" height="520" rx="14" fill="none" stroke="#d8d8d3" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <defs>
+    <filter id="cardShadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="8" stdDeviation="14" flood-color="#151512" flood-opacity="0.07"/>
+    </filter>
+  </defs>
 
-  <text x="52" y="66" font-size="12" font-weight="700" letter-spacing="2" fill="#8a8a82">CORE FEATURES</text>
+  <rect x="0" y="0" width="1200" height="560" rx="20" fill="#fafaf8"/>
+  <rect x="20" y="20" width="1160" height="520" rx="16" fill="#ffffff" stroke="#eceae3" stroke-width="1" filter="url(#cardShadow)"/>
 
-  <text x="52" y="106" font-size="30" font-weight="800" fill="#151512">One budget for a whole agent workflow,</text>
-  <text x="52" y="140" font-size="30" font-weight="800" fill="#151512">
-    <tspan fill="#151512">enforced </tspan><tspan fill="#a9791c">before each call</tspan><tspan fill="#151512">.</tspan>
+  <text x="52" y="66" font-size="12" font-weight="700" letter-spacing="2" fill="#9a978c">CORE FEATURES</text>
+
+  <text x="52" y="106" font-size="30" font-weight="800" fill="#1c1b17">One budget for a whole agent workflow,</text>
+  <text x="52" y="140" font-size="30" font-weight="800" fill="#1c1b17">
+    <tspan fill="#1c1b17">enforced </tspan><tspan fill="#a9791c">before each call</tspan><tspan fill="#1c1b17">.</tspan>
   </text>
 
-  <text x="1148" y="70" font-size="13" fill="#6b6b63" text-anchor="end">Governs the run, not the request: one ledger,</text>
-  <text x="1148" y="90" font-size="13" fill="#6b6b63" text-anchor="end">checked before every call, shared across every agent.</text>
+  <text x="1148" y="70" font-size="13" fill="#83806f" text-anchor="end">Governs the run, not the request: one ledger,</text>
+  <text x="1148" y="90" font-size="13" fill="#83806f" text-anchor="end">checked before every call, shared across every agent.</text>
 
   <!-- grid -->
-  <g stroke="#e2e2dd" stroke-width="1">
+  <g stroke="#f0eee6" stroke-width="1">
     <line x1="52" y1="176" x2="1148" y2="176"/>
     <line x1="52" y1="356" x2="1148" y2="356"/>
     <line x1="52" y1="536" x2="1148" y2="536"/>
@@ -21,81 +27,80 @@
     <line x1="784" y1="176" x2="784" y2="536"/>
   </g>
 
-  <!-- card template macro via repeated groups -->
   <!-- Card 1 -->
   <g transform="translate(52,196)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <path d="M8 15 L13 20 L22 9" stroke="#f6d34a" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">BEFORE THE CALL</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Enforced pre-call</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Checks the running total before</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">each call, not after. It refuses</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">the call that would break budget.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <path d="M9 16 L14 21 L23 10" stroke="#a9791c" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">BEFORE THE CALL</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Enforced pre-call</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">Checks the running total before</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">each call, not after. It refuses</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">the call that would break budget.</text>
   </g>
 
   <!-- Card 2 -->
   <g transform="translate(420,196)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <circle cx="15" cy="15" r="8" fill="none" stroke="#f6d34a" stroke-width="2.4"/>
-    <line x1="15" y1="15" x2="15" y2="9" stroke="#f6d34a" stroke-width="2.2" stroke-linecap="round"/>
-    <line x1="15" y1="15" x2="19" y2="17" stroke="#f6d34a" stroke-width="2.2" stroke-linecap="round"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">WHOLE RUN</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Run-scoped budget</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">One cap for the whole workflow,</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">not per request, so cheap calls</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">cannot quietly add up.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <circle cx="16" cy="16" r="8.5" fill="none" stroke="#a9791c" stroke-width="2.4"/>
+    <line x1="16" y1="16" x2="16" y2="9.5" stroke="#a9791c" stroke-width="2.2" stroke-linecap="round"/>
+    <line x1="16" y1="16" x2="20.5" y2="18" stroke="#a9791c" stroke-width="2.2" stroke-linecap="round"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">WHOLE RUN</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Run-scoped budget</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">One cap for the whole workflow,</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">not per request, so cheap calls</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">cannot quietly add up.</text>
   </g>
 
   <!-- Card 3 -->
   <g transform="translate(788,196)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <circle cx="8" cy="10" r="3.4" fill="#f6d34a"/>
-    <circle cx="22" cy="10" r="3.4" fill="#f6d34a"/>
-    <circle cx="15" cy="22" r="3.4" fill="#f6d34a"/>
-    <path d="M8 10 L15 22 M22 10 L15 22" stroke="#f6d34a" stroke-width="1.6"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">MULTI-AGENT</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Shared across processes</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Research, summarize and review</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">can be three services and still</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">draw from one ledger.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <circle cx="9" cy="11" r="3.2" fill="none" stroke="#a9791c" stroke-width="2"/>
+    <circle cx="23" cy="11" r="3.2" fill="none" stroke="#a9791c" stroke-width="2"/>
+    <circle cx="16" cy="23" r="3.2" fill="none" stroke="#a9791c" stroke-width="2"/>
+    <path d="M11.5 12.5 L14 20 M20.5 12.5 L18 20" stroke="#a9791c" stroke-width="1.6"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">MULTI-AGENT</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Shared across processes</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">Research, summarize and review</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">can be three services and still</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">draw from one ledger.</text>
   </g>
 
   <!-- Card 4 -->
   <g transform="translate(52,376)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <path d="M7 22 L15 8 L23 22" stroke="#f6d34a" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">POLICY</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Steers, not just stops</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Shrinks the next prompt, swaps</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">to a cheaper model, or flags a</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">loop. Stopping is the last resort.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <path d="M8 24 L16 9 L24 24" stroke="#a9791c" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">POLICY</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Steers, not just stops</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">Shrinks the next prompt, swaps</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">to a cheaper model, or flags a</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">loop. Stopping is the last resort.</text>
   </g>
 
   <!-- Card 5 -->
   <g transform="translate(420,376)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <rect x="7" y="7" width="16" height="16" rx="2" fill="none" stroke="#f6d34a" stroke-width="2.2"/>
-    <line x1="10" y1="13" x2="20" y2="13" stroke="#f6d34a" stroke-width="1.6"/>
-    <line x1="10" y1="17" x2="17" y2="17" stroke="#f6d34a" stroke-width="1.6"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">SPEND</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Nothing hides in a tool call</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Search results and file reads</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">that land in the next prompt are</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">real spend, and get counted.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <rect x="8" y="8" width="16" height="16" rx="2.5" fill="none" stroke="#a9791c" stroke-width="2.1"/>
+    <line x1="11" y1="14" x2="21" y2="14" stroke="#a9791c" stroke-width="1.6"/>
+    <line x1="11" y1="18" x2="18" y2="18" stroke="#a9791c" stroke-width="1.6"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">SPEND</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Nothing hides in a tool call</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">Search results and file reads</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">that land in the next prompt are</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">real spend, and get counted.</text>
   </g>
 
   <!-- Card 6 -->
   <g transform="translate(788,376)">
-    <rect x="0" y="0" width="30" height="30" rx="7" fill="#151512"/>
-    <circle cx="15" cy="15" r="3" fill="#f6d34a"/>
-    <circle cx="7" cy="8" r="2.2" fill="#f6d34a"/>
-    <circle cx="23" cy="8" r="2.2" fill="#f6d34a"/>
-    <circle cx="7" cy="22" r="2.2" fill="#f6d34a"/>
-    <circle cx="23" cy="22" r="2.2" fill="#f6d34a"/>
-    <text x="0" y="56" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#9a9a90">BATTERIES INCLUDED</text>
-    <text x="0" y="80" font-size="17" font-weight="700" fill="#151512">Governance, out of the box</text>
-    <text x="0" y="104" font-size="12.5" fill="#5c5c54">Ten documented policies covering</text>
-    <text x="0" y="122" font-size="12.5" fill="#5c5c54">the common ways a run goes</text>
-    <text x="0" y="140" font-size="12.5" fill="#5c5c54">wrong. Add your own alongside.</text>
+    <rect x="0" y="0" width="32" height="32" rx="9" fill="#f7edd4"/>
+    <circle cx="16" cy="16" r="2.6" fill="#a9791c"/>
+    <circle cx="9" cy="9" r="2" fill="#a9791c"/>
+    <circle cx="23" cy="9" r="2" fill="#a9791c"/>
+    <circle cx="9" cy="23" r="2" fill="#a9791c"/>
+    <circle cx="23" cy="23" r="2" fill="#a9791c"/>
+    <text x="0" y="58" font-size="10.5" font-weight="700" letter-spacing="1.5" fill="#a39f92">BATTERIES INCLUDED</text>
+    <text x="0" y="82" font-size="17" font-weight="700" fill="#1c1b17">Governance, out of the box</text>
+    <text x="0" y="106" font-size="12.5" fill="#6b6858">Ten documented policies covering</text>
+    <text x="0" y="124" font-size="12.5" fill="#6b6858">the common ways a run goes</text>
+    <text x="0" y="142" font-size="12.5" fill="#6b6858">wrong. Add your own alongside.</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Removed the standalone **Contributing** section, which duplicated the top "Open to contribution" callout (both pointed at CONTRIBUTING.md); the nav's Contributing link now points at the callout instead
- **See it work** cut down to just the two code blocks (the command and its output); the surrounding explanation was already covered by Core features
- Rewrote the Core features intro for a more natural flow ("Cheap calls add up fast, and a per-request limit never sees it coming...")
- Core features graphic given an explicit 850px width instead of stretching to 100% of the container
- Removed the last four decorative `<br>` tags sitting right after `<summary>` in collapsible sections
- Cherry-picked the "lighten the Core features graphic" commit that got stranded when #80 merged mid-push (pale-gold icon badges, soft shadow instead of dashed border)

Confirmed the new hero gif (from #79) and all of #80's changes are present on `main` — this branch is rebased cleanly on top of both.

## Test plan

- [x] Rebased onto current `main`, no conflicts
- [x] Grepped for dangling `#contributing` / removed-section references, found none
- [ ] Spot-check the rendered README once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)