### PR TITLE
docs: frame the hero gif in a table-cell border

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@
 
 <sub>Built by <b><a href="https://www.linkedin.com/in/susheemkoul/">Susheem Koul</a></b> and <b><a href="https://www.linkedin.com/in/tisha-chawla/">Tisha Chawla</a></b></sub>
 
+<table><tr><td>
+
 <a href="https://github.com/theagentplane/tokenops/raw/main/examples/demo-assets/videos/02_governance_on_budget_cap.webm">
 <img src="https://raw.githubusercontent.com/theagentplane/tokenops/main/examples/demo-assets/videos/02_governance_on_budget_cap.gif" alt="TokenOps demo: a governed Research to Summarize run halts when worst-case cost exceeds the remaining run budget, then the Dashboard shows spend and governance per agent" width="500" />
 </a>
+
+</td></tr></table>
 
 <sub><i>Governed Research → Summarize run: the budget cap halts spend mid-run, then the Dashboard attributes cost per agent. <a href="https://github.com/theagentplane/tokenops/raw/main/examples/demo-assets/videos/02_governance_on_budget_cap.webm">Full video</a>.</i></sub>
 


### PR DESCRIPTION
## Summary

PR #83 merged before this last commit got pushed, so it never got its own PR. Wraps the hero gif's \`<a><img></a>\` in a single-cell \`<table>\`, which gives it a real, visible border/frame in the rendered README — GitHub renders default table-cell borders, and this is the reliable way to get that effect since GitHub strips inline \`style\` attributes (no CSS box-shadow available otherwise).

## Test plan

- [x] Verified live on the branch's rendered GitHub page: a visible border frame now sits around the gif
- [ ] Final check once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)