### PR TITLE
Add short timeout to health checks to prevent sidebar hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add configurable short timeout (default 2.0s) for agent card fetch and health checks (#86)
+
 ## [0.2.0] - 2026-08-14
 
 ### Added

--- a/examples/a2a/client.py
+++ b/examples/a2a/client.py
@@ -124,17 +124,17 @@ async def delegate_summarize(
     )
 
 
-def check_health_sync(url: str) -> bool:
+def check_health_sync(url: str, *, timeout: float = 2.0) -> bool:
     try:
-        fetch_agent_card_sync(url)
+        fetch_agent_card_sync(url, timeout=timeout)
         return True
     except Exception:
         return False
 
 
-async def check_health(url: str) -> bool:
+async def check_health(url: str, *, timeout: float = 2.0) -> bool:
     try:
-        await fetch_agent_card(url)
+        await fetch_agent_card(url, timeout=timeout)
         return True
     except Exception:
         return False

--- a/examples/a2a/server.py
+++ b/examples/a2a/server.py
@@ -69,9 +69,9 @@ async def post_task(
         return response.json()
 
 
-async def fetch_agent_card(url: str) -> dict[str, Any]:
+async def fetch_agent_card(url: str, *, timeout: float = 2.0) -> dict[str, Any]:
     base = url.rstrip("/")
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.get(f"{base}/.well-known/agent-card.json")
         response.raise_for_status()
         return response.json()
@@ -114,9 +114,9 @@ def post_task_sync(
         return response.json()
 
 
-def fetch_agent_card_sync(url: str) -> dict[str, Any]:
+def fetch_agent_card_sync(url: str, *, timeout: float = 2.0) -> dict[str, Any]:
     base = url.rstrip("/")
-    with httpx.Client(timeout=10.0) as client:
+    with httpx.Client(timeout=timeout) as client:
         response = client.get(f"{base}/.well-known/agent-card.json")
         response.raise_for_status()
         return response.json()

--- a/tests/test_a2a_health.py
+++ b/tests/test_a2a_health.py
@@ -1,0 +1,140 @@
+"""Tests for agent card fetching and health check timeouts."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from examples.a2a import client
+from examples.a2a.client import check_health, check_health_sync
+from examples.a2a.server import fetch_agent_card, fetch_agent_card_sync
+
+
+def test_fetch_agent_card_sync_default_timeout(monkeypatch):
+    recorded_timeout = []
+
+    class DummyClient:
+        def __init__(self, timeout=None):
+            recorded_timeout.append(timeout)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def get(self, url):
+            return httpx.Response(
+                200, json={"name": "test-agent"}, request=httpx.Request("GET", url)
+            )
+
+    monkeypatch.setattr(httpx, "Client", DummyClient)
+    res = fetch_agent_card_sync("http://localhost:8000")
+    assert res == {"name": "test-agent"}
+    assert recorded_timeout == [2.0]
+
+
+def test_fetch_agent_card_sync_custom_timeout(monkeypatch):
+    recorded_timeout = []
+
+    class DummyClient:
+        def __init__(self, timeout=None):
+            recorded_timeout.append(timeout)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def get(self, url):
+            return httpx.Response(
+                200, json={"name": "test-agent"}, request=httpx.Request("GET", url)
+            )
+
+    monkeypatch.setattr(httpx, "Client", DummyClient)
+    res = fetch_agent_card_sync("http://localhost:8000", timeout=5.5)
+    assert res == {"name": "test-agent"}
+    assert recorded_timeout == [5.5]
+
+
+@pytest.mark.asyncio
+async def test_fetch_agent_card_async_default_timeout(monkeypatch):
+    recorded_timeout = []
+
+    class DummyAsyncClient:
+        def __init__(self, timeout=None):
+            recorded_timeout.append(timeout)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        async def get(self, url):
+            return httpx.Response(
+                200, json={"name": "test-agent"}, request=httpx.Request("GET", url)
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    res = await fetch_agent_card("http://localhost:8000")
+    assert res == {"name": "test-agent"}
+    assert recorded_timeout == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_agent_card_async_custom_timeout(monkeypatch):
+    recorded_timeout = []
+
+    class DummyAsyncClient:
+        def __init__(self, timeout=None):
+            recorded_timeout.append(timeout)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        async def get(self, url):
+            return httpx.Response(
+                200, json={"name": "test-agent"}, request=httpx.Request("GET", url)
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    res = await fetch_agent_card("http://localhost:8000", timeout=4.0)
+    assert res == {"name": "test-agent"}
+    assert recorded_timeout == [4.0]
+
+
+def test_check_health_sync_success_and_failure(monkeypatch):
+    calls = []
+
+    def fake_fetch(url, *, timeout=2.0):
+        calls.append((url, timeout))
+        if "offline" in url:
+            raise httpx.ConnectError("Offline")
+        return {"name": "ok"}
+
+    monkeypatch.setattr(client, "fetch_agent_card_sync", fake_fetch)
+
+    assert check_health_sync("http://localhost:8000") is True
+    assert check_health_sync("http://offline:8000", timeout=1.5) is False
+    assert calls == [("http://localhost:8000", 2.0), ("http://offline:8000", 1.5)]
+
+
+@pytest.mark.asyncio
+async def test_check_health_async_success_and_failure(monkeypatch):
+    calls = []
+
+    async def fake_fetch(url, *, timeout=2.0):
+        calls.append((url, timeout))
+        if "offline" in url:
+            raise httpx.ConnectError("Offline")
+        return {"name": "ok"}
+
+    monkeypatch.setattr(client, "fetch_agent_card", fake_fetch)
+
+    assert await check_health("http://localhost:8000") is True
+    assert await check_health("http://offline:8000", timeout=1.2) is False
+    assert calls == [("http://localhost:8000", 2.0), ("http://offline:8000", 1.2)]


### PR DESCRIPTION
Fixes #86

Summary
Add a configurable timeout parameter (default 2.0s) to fetch_agent_card, fetch_agent_card_sync, check_health, and check_health_sync. This prevents the Chat sidebar from blocking for 20s when local agent servers are offline.

Changes
- Add timeout parameter defaulting to 2.0s in examples/a2a/server.py and examples/a2a/client.py
- Add unit tests in tests/test_a2a_health.py verifying timeout propagation and error handling
- Update CHANGELOG.md under Unreleased
