### PR TITLE
test: declare pytest-asyncio as a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
+  "pytest-asyncio>=0.24",
   "build>=1.2",
   "twine>=6.0",
   "ruff>=0.8",
@@ -71,6 +72,7 @@ Changelog = "https://github.com/theagentplane/tokenops/blob/main/CHANGELOG.md"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src", "."]
+asyncio_mode = "strict"
 markers = [
   "e2e: example / bench end-to-end tests (not run in default CI)",
   "live: requires API keys or vendored frameworks",


### PR DESCRIPTION
## Summary
- `tests/test_a2a_health.py` (added in #97) uses `@pytest.mark.asyncio`, but `pytest-asyncio` was never declared in the `dev` extras — a fresh `pip install -e ".[dev]"` + `make test` fails those 4 async tests until someone installs the plugin by hand
- Adds `pytest-asyncio>=0.24` to `dev`, and pins `asyncio_mode = "strict"` explicitly (matches the plugin's existing default, just makes it explicit)

## Test plan
- [x] Uninstalled pytest-asyncio, reinstalled via \`pip install -e \".[dev,examples]\"\`, confirmed it's now pulled in automatically
- [x] \`pytest -q\`: 225 passed, 2 skipped, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)