### PR TITLE
release: 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
 ### Changed
 
 - Add configurable short timeout (default 2.0s) for agent card fetch and health checks (#86)
 - Pin `streamlit` to `>=1.38,<2` instead of an unbounded lower-bound-only range (#84)
+- Declare `pytest-asyncio` as a dev dependency so `make test` passes on a fresh clone
 
 ## [0.2.0] - 2026-08-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-tokenops"
-version = "0.2.0"
+version = "0.2.1"
 description = "TokenOps control plane and SDK for run-aware agent token governance"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokenops/__init__.py
+++ b/src/tokenops/__init__.py
@@ -4,7 +4,7 @@ from tokenops.env import load_env
 
 load_env()
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 def init() -> None:


### PR DESCRIPTION
## Summary
- Bumps version 0.2.0 -> 0.2.1 in `pyproject.toml` and `src/tokenops/__init__.py`
- Moves CHANGELOG `[Unreleased]` entries under `[0.2.1] - 2026-09-04`

Covers since 0.2.0:
- Configurable short timeout (default 2.0s) for agent card fetch / health checks (#86, #97)
- `streamlit` pinned to `>=1.38,<2` instead of unbounded (#84, #99)
- `pytest-asyncio` declared as a dev dependency (#100)

## Test plan
- [x] \`python -m build\` succeeds, produces \`agent_tokenops-0.2.1\` sdist + wheel
- [x] \`twine check dist/*\` passes on both

Once merged, run **Actions -> Release -> Run workflow** on \`main\` to tag, build, and publish to PyPI via Trusted Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)