### PR TITLE
docs: credit external contributors by handle in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add configurable short timeout (default 2.0s) for agent card fetch and health checks (#86)
-- Pin `streamlit` to `>=1.38,<2` instead of an unbounded lower-bound-only range (#84)
+- Add configurable short timeout (default 2.0s) for agent card fetch and health checks (#86, thanks [@HeaTTap](https://github.com/HeaTTap))
+- Pin `streamlit` to `>=1.38,<2` instead of an unbounded lower-bound-only range (#84, thanks [@SurajPatelPro](https://github.com/SurajPatelPro))
 - Declare `pytest-asyncio` as a dev dependency so `make test` passes on a fresh clone
 
 ## [0.2.0] - 2026-08-14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,9 @@ on a change we cannot merge, and it gives the PR something to close.
 2. Branch, then keep the PR focused (one concern per change).
 3. Add or update tests when behavior changes.
 4. Run `make lint` and `make test` before opening the PR.
-5. Update `CHANGELOG.md` for user-visible changes (see `RELEASING.md`).
+5. Update `CHANGELOG.md` for user-visible changes (see `RELEASING.md`). If you're
+   an external contributor, credit yourself in the entry, e.g.
+   `(#123, thanks @yourhandle)` — maintainers will do this for you if you forget.
 6. Link the issue in the PR description (`Fixes #123`).
 
 Typos, broken links, and formatting fixes can skip step 1 and go straight to a


### PR DESCRIPTION
## Summary
- CHANGELOG entries for #86 and #84 now credit the actual contributors: `thanks @HeaTTap` and `thanks @SurajPatelPro`
- Adds the convention to CONTRIBUTING.md so it's expected going forward, not a one-off

Context: a project that only cites issue numbers in its changelog is easy to overlook as a place where individual contributions matter. Public credit by handle is close to free and is one of the better levers for getting a first-time contributor to come back for a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)